### PR TITLE
docs: define curated software catalogue schema

### DIFF
--- a/docs/product/catalogue.fixtures.json
+++ b/docs/product/catalogue.fixtures.json
@@ -1,0 +1,260 @@
+{
+  "schemaVersion": "1.0.0",
+  "catalogueVersion": "0.1.0",
+  "applications": [
+    {
+      "id": "git",
+      "name": "Git",
+      "publisher": "Git Project",
+      "description": "Distributed version control system.",
+      "categories": ["development"],
+      "tags": ["source-control", "cli"],
+      "lifecycle": {"status": "active"},
+      "recommendations": [
+        {"profile": "development", "level": "essential", "reasonKey": "development.source-control"}
+      ],
+      "requirements": {
+        "minimum": {"minRamMiB": 512, "minFreeStorageMiB": 500, "gpuRequired": false, "architectures": ["x64", "arm64", "x86"]},
+        "recommended": {"minRamMiB": 4096, "minFreeStorageMiB": 1024, "gpuRequired": false, "architectures": ["x64", "arm64", "x86"]}
+      },
+      "platformSupport": [
+        {"platform": "windows", "status": "supported", "architectures": ["x64", "arm64", "x86"]},
+        {"platform": "macos", "status": "planned", "architectures": ["x64", "arm64"]}
+      ],
+      "providers": [
+        {"platform": "windows", "type": "winget", "packageId": "Git.Git", "source": "winget", "scopePreference": "any"},
+        {"platform": "macos", "type": "homebrew-formula", "token": "git"}
+      ],
+      "verification": [
+        {"platform": "windows", "type": "provider-query"},
+        {"platform": "windows", "type": "command-version", "executable": "git", "arguments": ["--version"]},
+        {"platform": "macos", "type": "provider-query"}
+      ],
+      "dependencies": [],
+      "conflicts": [],
+      "curation": {"homepage": "https://git-scm.com/", "license": "GPL-2.0-only", "trust": "official-publisher"}
+    },
+    {
+      "id": "visual-studio-code",
+      "name": "Visual Studio Code",
+      "publisher": "Microsoft",
+      "description": "Extensible source-code editor for development workflows.",
+      "categories": ["development"],
+      "tags": ["editor", "ide"],
+      "lifecycle": {"status": "active"},
+      "recommendations": [
+        {"profile": "development", "level": "recommended", "reasonKey": "development.code-editor"},
+        {"profile": "training", "level": "recommended", "reasonKey": "training.code-editor"}
+      ],
+      "requirements": {
+        "minimum": {"minRamMiB": 2048, "minFreeStorageMiB": 1000, "gpuRequired": false, "architectures": ["x64", "arm64"]},
+        "recommended": {"minRamMiB": 4096, "minFreeStorageMiB": 1024, "gpuRequired": false, "architectures": ["x64", "arm64"]}
+      },
+      "platformSupport": [
+        {"platform": "windows", "status": "supported", "architectures": ["x64", "arm64"]},
+        {"platform": "macos", "status": "planned", "architectures": ["x64", "arm64"]}
+      ],
+      "providers": [
+        {"platform": "windows", "type": "winget", "packageId": "Microsoft.VisualStudioCode", "source": "winget", "scopePreference": "user"},
+        {"platform": "macos", "type": "homebrew-cask", "token": "visual-studio-code"}
+      ],
+      "verification": [
+        {"platform": "windows", "type": "provider-query"},
+        {"platform": "macos", "type": "provider-query"}
+      ],
+      "dependencies": [],
+      "conflicts": [],
+      "curation": {"homepage": "https://code.visualstudio.com/", "license": "Microsoft Software License Terms", "trust": "official-publisher"}
+    },
+    {
+      "id": "firefox",
+      "name": "Mozilla Firefox",
+      "publisher": "Mozilla",
+      "description": "Privacy-oriented web browser.",
+      "categories": ["browser"],
+      "tags": ["browser", "web"],
+      "lifecycle": {"status": "active"},
+      "recommendations": [
+        {"profile": "personal", "level": "recommended", "reasonKey": "personal.web-browser"},
+        {"profile": "development", "level": "optional", "reasonKey": "development.browser-testing"}
+      ],
+      "requirements": {
+        "minimum": {"minRamMiB": 2048, "minFreeStorageMiB": 500, "gpuRequired": false, "architectures": ["x64", "arm64"]},
+        "recommended": {"minRamMiB": 4096, "minFreeStorageMiB": 1024, "gpuRequired": false, "architectures": ["x64", "arm64"]}
+      },
+      "platformSupport": [
+        {"platform": "windows", "status": "supported", "architectures": ["x64", "arm64"]},
+        {"platform": "macos", "status": "planned", "architectures": ["x64", "arm64"]}
+      ],
+      "providers": [
+        {"platform": "windows", "type": "winget", "packageId": "Mozilla.Firefox", "source": "winget", "scopePreference": "any"},
+        {"platform": "macos", "type": "homebrew-cask", "token": "firefox"}
+      ],
+      "verification": [
+        {"platform": "windows", "type": "provider-query"},
+        {"platform": "macos", "type": "provider-query"}
+      ],
+      "dependencies": [],
+      "conflicts": [],
+      "curation": {"homepage": "https://www.mozilla.org/firefox/", "license": "MPL-2.0", "trust": "official-publisher"}
+    },
+    {
+      "id": "vlc",
+      "name": "VLC media player",
+      "publisher": "VideoLAN",
+      "description": "Cross-platform media player.",
+      "categories": ["media"],
+      "tags": ["audio", "video", "player"],
+      "lifecycle": {"status": "active"},
+      "recommendations": [
+        {"profile": "personal", "level": "recommended", "reasonKey": "personal.media-player"},
+        {"profile": "training", "level": "optional", "reasonKey": "training.media-playback"}
+      ],
+      "requirements": {
+        "minimum": {"minRamMiB": 1024, "minFreeStorageMiB": 500, "gpuRequired": false, "architectures": ["x64", "arm64"]},
+        "recommended": {"minRamMiB": 4096, "minFreeStorageMiB": 1024, "gpuRequired": false, "architectures": ["x64", "arm64"]}
+      },
+      "platformSupport": [
+        {"platform": "windows", "status": "supported", "architectures": ["x64", "arm64"]},
+        {"platform": "macos", "status": "planned", "architectures": ["x64", "arm64"]}
+      ],
+      "providers": [
+        {"platform": "windows", "type": "winget", "packageId": "VideoLAN.VLC", "source": "winget", "scopePreference": "any"},
+        {"platform": "macos", "type": "homebrew-cask", "token": "vlc"}
+      ],
+      "verification": [
+        {"platform": "windows", "type": "provider-query"},
+        {"platform": "macos", "type": "provider-query"}
+      ],
+      "dependencies": [],
+      "conflicts": [],
+      "curation": {"homepage": "https://www.videolan.org/vlc/", "license": "GPL-2.0-or-later", "trust": "official-publisher"}
+    },
+    {
+      "id": "7zip",
+      "name": "7-Zip",
+      "publisher": "Igor Pavlov",
+      "description": "File archiver with support for common archive formats.",
+      "categories": ["utilities"],
+      "tags": ["archive", "compression"],
+      "lifecycle": {"status": "active"},
+      "recommendations": [
+        {"profile": "personal", "level": "recommended", "reasonKey": "personal.archive-tool"},
+        {"profile": "development", "level": "recommended", "reasonKey": "development.archive-tool"},
+        {"profile": "business", "level": "recommended", "reasonKey": "business.archive-tool"}
+      ],
+      "requirements": {
+        "minimum": {"minRamMiB": 256, "minFreeStorageMiB": 200, "gpuRequired": false, "architectures": ["x64", "arm64", "x86"]},
+        "recommended": {"minRamMiB": 4096, "minFreeStorageMiB": 1024, "gpuRequired": false, "architectures": ["x64", "arm64", "x86"]}
+      },
+      "platformSupport": [
+        {"platform": "windows", "status": "supported", "architectures": ["x64", "arm64", "x86"]},
+        {"platform": "macos", "status": "planned", "architectures": ["x64", "arm64"]}
+      ],
+      "providers": [
+        {"platform": "windows", "type": "winget", "packageId": "7zip.7zip", "source": "winget", "scopePreference": "any"},
+        {"platform": "macos", "type": "homebrew-formula", "token": "sevenzip"}
+      ],
+      "verification": [
+        {"platform": "windows", "type": "provider-query"},
+        {"platform": "macos", "type": "provider-query"}
+      ],
+      "dependencies": [],
+      "conflicts": [],
+      "curation": {"homepage": "https://www.7-zip.org/", "license": "LGPL-2.1-or-later", "trust": "official-publisher"}
+    },
+    {
+      "id": "obs-studio",
+      "name": "OBS Studio",
+      "publisher": "OBS Project",
+      "description": "Open-source video recording and live-streaming application.",
+      "categories": ["media", "creation"],
+      "tags": ["recording", "streaming"],
+      "lifecycle": {"status": "active"},
+      "recommendations": [
+        {"profile": "creation", "level": "recommended", "reasonKey": "creation.screen-recording"},
+        {"profile": "training", "level": "recommended", "reasonKey": "training.screen-recording"}
+      ],
+      "requirements": {
+        "minimum": {"minRamMiB": 4096, "minFreeStorageMiB": 1000, "gpuRequired": true, "architectures": ["x64", "arm64"]},
+        "recommended": {"minRamMiB": 4096, "minFreeStorageMiB": 1024, "gpuRequired": true, "architectures": ["x64", "arm64"]}
+      },
+      "platformSupport": [
+        {"platform": "windows", "status": "supported", "architectures": ["x64", "arm64"]},
+        {"platform": "macos", "status": "planned", "architectures": ["x64", "arm64"]}
+      ],
+      "providers": [
+        {"platform": "windows", "type": "winget", "packageId": "OBSProject.OBSStudio", "source": "winget", "scopePreference": "any"},
+        {"platform": "macos", "type": "homebrew-cask", "token": "obs"}
+      ],
+      "verification": [
+        {"platform": "windows", "type": "provider-query"},
+        {"platform": "macos", "type": "provider-query"}
+      ],
+      "dependencies": [],
+      "conflicts": [],
+      "curation": {"homepage": "https://obsproject.com/", "license": "GPL-2.0-or-later", "trust": "official-publisher"}
+    },
+    {
+      "id": "powertoys",
+      "name": "Microsoft PowerToys",
+      "publisher": "Microsoft",
+      "description": "Windows productivity utilities for power users.",
+      "categories": ["system", "productivity"],
+      "tags": ["windows", "utilities"],
+      "lifecycle": {"status": "active"},
+      "recommendations": [
+        {"profile": "development", "level": "recommended", "reasonKey": "development.windows-productivity"},
+        {"profile": "business", "level": "optional", "reasonKey": "business.windows-productivity"}
+      ],
+      "requirements": {
+        "minimum": {"minRamMiB": 2048, "minFreeStorageMiB": 1000, "gpuRequired": false, "architectures": ["x64", "arm64"]},
+        "recommended": {"minRamMiB": 4096, "minFreeStorageMiB": 1024, "gpuRequired": false, "architectures": ["x64", "arm64"]}
+      },
+      "platformSupport": [
+        {"platform": "windows", "status": "supported", "architectures": ["x64", "arm64"]}
+      ],
+      "providers": [
+        {"platform": "windows", "type": "winget", "packageId": "Microsoft.PowerToys", "source": "winget", "scopePreference": "any"}
+      ],
+      "verification": [
+        {"platform": "windows", "type": "provider-query"}
+      ],
+      "dependencies": [],
+      "conflicts": [],
+      "curation": {"homepage": "https://github.com/microsoft/PowerToys", "license": "MIT", "trust": "official-publisher"}
+    },
+    {
+      "id": "docker-desktop",
+      "name": "Docker Desktop",
+      "publisher": "Docker",
+      "description": "Desktop environment for running and managing containers.",
+      "categories": ["development"],
+      "tags": ["containers", "docker"],
+      "lifecycle": {"status": "active"},
+      "recommendations": [
+        {"profile": "development", "level": "optional", "reasonKey": "development.containers"}
+      ],
+      "requirements": {
+        "minimum": {"minRamMiB": 8192, "minFreeStorageMiB": 8192, "gpuRequired": false, "architectures": ["x64", "arm64"]},
+        "recommended": {"minRamMiB": 8192, "minFreeStorageMiB": 8192, "gpuRequired": false, "architectures": ["x64", "arm64"]}
+      },
+      "platformSupport": [
+        {"platform": "windows", "status": "supported", "architectures": ["x64", "arm64"]},
+        {"platform": "macos", "status": "planned", "architectures": ["x64", "arm64"]}
+      ],
+      "providers": [
+        {"platform": "windows", "type": "winget", "packageId": "Docker.DockerDesktop", "source": "winget", "scopePreference": "any"},
+        {"platform": "macos", "type": "homebrew-cask", "token": "docker"}
+      ],
+      "verification": [
+        {"platform": "windows", "type": "provider-query"},
+        {"platform": "windows", "type": "command-version", "executable": "docker", "arguments": ["--version"]},
+        {"platform": "macos", "type": "provider-query"}
+      ],
+      "dependencies": [],
+      "conflicts": [],
+      "curation": {"homepage": "https://www.docker.com/products/docker-desktop/", "license": "Docker Subscription Service Agreement", "trust": "official-publisher"}
+    }
+  ]
+}

--- a/docs/product/software-catalogue.md
+++ b/docs/product/software-catalogue.md
@@ -1,0 +1,586 @@
+# AgenStart Software Catalogue
+
+## Purpose
+
+The AgenStart catalogue is the curated product model that describes software AgenStart may recommend, install, verify and reproduce across supported operating systems.
+
+It is intentionally **not** a copy of WinGet, Homebrew or any other provider catalogue.
+
+AgenStart owns the product meaning of an application; package providers only describe how that application is acquired on a specific platform.
+
+```text
+AgenStart application
+        │
+        ├── product metadata
+        ├── recommendation metadata
+        ├── capability requirements
+        ├── dependencies / conflicts
+        ├── lifecycle / trust
+        │
+        └── provider mappings
+              ├── Windows → WinGet
+              └── macOS   → Homebrew/Cask (future)
+```
+
+This separation is a core architectural rule.
+
+---
+
+## Design goals
+
+The catalogue must be:
+
+- curated rather than automatically mirroring an external repository;
+- versioned and schema-validated;
+- independent from any single package manager;
+- deterministic enough for recommendation tests;
+- portable across Windows and future macOS support;
+- safe when provider metadata becomes stale;
+- explicit about compatibility, dependencies and conflicts;
+- explainable to the user;
+- free from executable shell fragments.
+
+---
+
+## Canonical application identity
+
+Every application has one immutable AgenStart `id`.
+
+Examples:
+
+```text
+visual-studio-code
+git
+firefox
+vlc
+obs-studio
+7zip
+powertoys
+docker-desktop
+```
+
+The canonical ID is **not** a WinGet ID, Homebrew token, executable name or publisher identifier.
+
+It belongs to AgenStart and remains stable even if a package provider changes.
+
+Example:
+
+```text
+AgenStart id: visual-studio-code
+
+Windows provider:
+  winget → Microsoft.VisualStudioCode
+
+macOS provider:
+  homebrew-cask → visual-studio-code
+```
+
+This allows profiles, recommendation rules and exported setups to reference `visual-studio-code` without knowing how it is installed on the current OS.
+
+Canonical IDs use lowercase kebab-case and must never be silently reused for a different product.
+
+---
+
+## Catalogue versions
+
+The catalogue has two independent versions:
+
+### `schemaVersion`
+Version of the contract understood by AgenStart.
+
+Example:
+
+```json
+"schemaVersion": "1.0.0"
+```
+
+Changing field semantics, required properties or structural compatibility requires a schema version change.
+
+### `catalogueVersion`
+Version of the curated content.
+
+Example:
+
+```json
+"catalogueVersion": "2026.9.0"
+```
+
+Adding an application, updating a provider mapping or changing recommendation metadata increments the catalogue version without necessarily changing the schema.
+
+The runtime must reject unsupported schema major versions rather than guessing.
+
+---
+
+## Application model
+
+Each application contains the following product-level concerns.
+
+### Identity and presentation
+
+- `id`
+- `name`
+- `publisher`
+- `description`
+- `categories`
+- `tags`
+
+These fields belong to AgenStart and must not be populated dynamically from package-manager output at runtime.
+
+Provider metadata may be used for validation, but it does not own the product display model.
+
+---
+
+## Lifecycle
+
+Every application has an explicit lifecycle:
+
+```text
+active
+  available for recommendation/installation
+
+deprecated
+  still understood but should not normally be recommended
+
+blocked
+  must not be installed through AgenStart
+```
+
+A deprecated or blocked entry may declare a `replacementId`.
+
+Example:
+
+```json
+{
+  "status": "deprecated",
+  "replacementId": "new-product",
+  "message": "Publisher replaced this product."
+}
+```
+
+A blocked entry is a safety state. The runtime must fail closed even if the underlying provider can still install it.
+
+---
+
+## Recommendations
+
+Recommendation metadata identifies how an app relates to an AgenStart profile.
+
+Supported initial profiles:
+
+```text
+personal
+development
+business
+creation
+training
+```
+
+Recommendation levels:
+
+```text
+essential
+recommended
+optional
+```
+
+Every recommendation includes a stable `reasonKey` rather than hard-coded UI prose.
+
+Example:
+
+```json
+{
+  "profile": "development",
+  "level": "essential",
+  "reasonKey": "development.source-control"
+}
+```
+
+The recommendation engine will combine this metadata with machine capability, installed-software state and future user preferences. The catalogue does not itself make the final decision.
+
+---
+
+## Capability requirements
+
+An application can define `minimum` and `recommended` capability requirements.
+
+Initial V1 vocabulary:
+
+- minimum RAM;
+- minimum free storage;
+- supported CPU architectures;
+- whether a GPU is required.
+
+Example:
+
+```json
+{
+  "minimum": {
+    "minRamMiB": 4096,
+    "minFreeStorageMiB": 1000,
+    "architectures": ["x64", "arm64"]
+  },
+  "recommended": {
+    "minRamMiB": 8192,
+    "minFreeStorageMiB": 3000,
+    "architectures": ["x64", "arm64"]
+  }
+}
+```
+
+Requirements must describe meaningful product constraints rather than attempting to duplicate every vendor specification.
+
+Unknown machine values must not automatically be interpreted as compatible.
+
+---
+
+## Platform support
+
+Platform support is separate from provider mappings.
+
+This distinction matters because an application can support an OS even when AgenStart has not yet implemented an installation provider for it.
+
+Statuses:
+
+```text
+supported
+planned
+unsupported
+```
+
+Example:
+
+```json
+[
+  {
+    "platform": "windows",
+    "status": "supported",
+    "architectures": ["x64", "arm64"]
+  },
+  {
+    "platform": "macos",
+    "status": "planned",
+    "architectures": ["x64", "arm64"]
+  }
+]
+```
+
+---
+
+## Provider mappings
+
+Provider metadata is deliberately isolated from product metadata.
+
+### Windows / WinGet
+
+A WinGet mapping contains:
+
+- platform;
+- provider type;
+- exact `packageId`;
+- source (`winget` or `msstore`);
+- optional installation-scope preference;
+- optional installer-type preference.
+
+Example:
+
+```json
+{
+  "platform": "windows",
+  "type": "winget",
+  "packageId": "Microsoft.VisualStudioCode",
+  "source": "winget",
+  "scopePreference": "user"
+}
+```
+
+AgenStart must install WinGet packages using an exact identifier, equivalent to the intent of:
+
+```text
+winget install --id <PackageIdentifier> -e --source <source>
+```
+
+Provider search results must never be treated as authoritative enough to install a fuzzy match.
+
+WinGet itself models packages with a unique `PackageIdentifier`, supports architecture and installer-type selection, and can expose duplicate entries across sources; the AgenStart mapping therefore stores both package ID and source explicitly.
+
+### macOS / Homebrew
+
+Future macOS mappings use either:
+
+```text
+homebrew-formula
+homebrew-cask
+```
+
+with an exact Homebrew token.
+
+Example:
+
+```json
+{
+  "platform": "macos",
+  "type": "homebrew-cask",
+  "token": "visual-studio-code"
+}
+```
+
+Homebrew itself models OS/architecture requirements and dependencies, but AgenStart keeps its own normalized product-level constraints so recommendation logic does not depend on Homebrew internals.
+
+---
+
+## Dependencies
+
+Dependencies reference **canonical AgenStart IDs only**.
+
+Example:
+
+```json
+"dependencies": ["git"]
+```
+
+Provider package identifiers must never appear in the dependency graph.
+
+Why:
+
+```text
+AgenStart.Core
+      │
+      └── canonical dependency graph
+                    │
+                    ▼
+             platform provider
+```
+
+This prevents the core from becoming coupled to WinGet or Homebrew.
+
+The initial catalogue should use dependencies sparingly. Package-manager-native dependencies remain the provider's responsibility unless AgenStart needs the dependency for product semantics.
+
+---
+
+## Conflicts
+
+Conflicts also reference canonical AgenStart IDs.
+
+Example:
+
+```json
+"conflicts": ["competing-product"]
+```
+
+A conflict means AgenStart should prevent or explicitly resolve a conflicting plan before execution.
+
+Provider-level conflicts may still exist independently; these are execution concerns and must be surfaced by the provider adapter if encountered.
+
+---
+
+## Verification
+
+Installation success must not be inferred from exit code alone.
+
+Each application declares one or more verification strategies.
+
+Initial strategies:
+
+```text
+provider-query
+registry-display-name
+executable-path
+bundle-id            # macOS future
+command-version
+```
+
+Example:
+
+```json
+{
+  "platform": "windows",
+  "type": "command-version",
+  "value": "git --version"
+}
+```
+
+Security rule: verification metadata is **not arbitrary shell execution**.
+
+The runtime implementation must translate supported verification rule types into constrained operations. Catalogue text is never passed directly to a shell without a typed allowlisted interpreter.
+
+For V1, `provider-query` should be preferred where reliable, with secondary verification only when needed.
+
+---
+
+## Trust and curation
+
+A catalogue entry includes:
+
+- official homepage;
+- license label;
+- trust classification;
+- optional curator notes.
+
+Initial trust classifications:
+
+```text
+official-publisher
+trusted-community
+```
+
+AgenStart should prefer official publisher package mappings whenever available.
+
+A catalogue entry must never include:
+
+- arbitrary download mirrors;
+- cracks or license bypasses;
+- opaque shell scripts;
+- user-provided executable URLs promoted automatically to trusted status.
+
+Trust is part of the product contract.
+
+---
+
+## Validation rules
+
+A catalogue is invalid when any of the following occurs:
+
+- schema validation fails;
+- canonical IDs are duplicated;
+- an application references itself as a dependency or conflict;
+- dependency/conflict IDs do not exist;
+- two provider mappings for the same application collide ambiguously;
+- an `active` application has no usable provider for a platform marked `supported`;
+- a blocked application is selected for installation;
+- a replacement ID does not exist;
+- duplicate profile recommendations exist for the same app/profile pair;
+- provider-specific values appear in canonical dependency/conflict fields;
+- the schema major version is unsupported.
+
+These cross-entry constraints are validated in application code in addition to JSON Schema validation.
+
+---
+
+## Failure behaviour
+
+The catalogue must fail closed.
+
+### Invalid whole catalogue
+
+If the bundled catalogue does not pass structural validation at startup:
+
+- AgenStart must not execute installations;
+- diagnostics identify the validation failure;
+- the UI can still explain that the catalogue is unavailable;
+- arbitrary partial parsing is prohibited.
+
+### Invalid individual external update
+
+If a future remotely-updated catalogue fails validation:
+
+- keep the last known-good validated catalogue;
+- reject the invalid update;
+- never merge unvalidated fragments into active state.
+
+### Missing provider
+
+If an application exists but has no provider for the current platform:
+
+```text
+Known product ≠ installable product
+```
+
+It may be displayed as unavailable/planned, but cannot enter the execution queue.
+
+### Stale provider ID
+
+If a provider mapping no longer resolves:
+
+- mark the provider unavailable for that session;
+- do not fuzzy-search and install a similarly named package;
+- surface a catalogue/provider maintenance diagnostic.
+
+---
+
+## Runtime ownership
+
+The catalogue layer should expose domain concepts such as:
+
+```text
+ApplicationDefinition
+CanonicalApplicationId
+PlatformSupport
+ProviderReference
+RecommendationMetadata
+CapabilityRequirements
+VerificationPolicy
+ApplicationLifecycle
+```
+
+The core must never expose WinGet process arguments or Homebrew command strings as catalogue domain objects.
+
+Provider adapters translate typed provider references into execution operations.
+
+---
+
+## Suggested repository structure
+
+```text
+src/
+├── AgenStart.Core/
+│   └── Catalogue/
+│       ├── ApplicationDefinition.cs
+│       ├── Catalogue.cs
+│       ├── CatalogueValidator.cs
+│       └── ...
+│
+├── AgenStart.Platform.Windows/
+│   └── Packages/
+│       └── WinGetProvider.cs
+│
+└── AgenStart.Platform.MacOS/
+    └── Packages/
+        └── HomebrewProvider.cs       # future
+
+catalogue/
+├── catalogue.json
+└── software-catalogue.schema.json
+```
+
+The initial repository documentation includes a formal JSON Schema and representative fixtures before production code is introduced.
+
+---
+
+## Initial fixture set
+
+The schema is exercised against representative applications covering different categories and complexity:
+
+- Git
+- Visual Studio Code
+- Mozilla Firefox
+- VLC
+- 7-Zip
+- OBS Studio
+- Microsoft PowerToys
+- Docker Desktop
+
+These fixtures are examples for contract design and tests. They are not yet the production catalogue.
+
+---
+
+## Out of scope for this issue
+
+This issue does not implement:
+
+- provider execution;
+- installed-software detection;
+- remote catalogue delivery;
+- catalogue cryptographic signing;
+- recommendation scoring;
+- UI catalogue browsing;
+- licensing/subscription entitlement logic.
+
+Those concerns build on this contract rather than being embedded into it.
+
+---
+
+## Architectural rule
+
+> **AgenStart knows applications. Providers know packages.**
+
+If a core feature needs to know that Visual Studio Code is `Microsoft.VisualStudioCode`, the abstraction has leaked.

--- a/docs/product/software-catalogue.md
+++ b/docs/product/software-catalogue.md
@@ -395,13 +395,14 @@ Example:
 {
   "platform": "windows",
   "type": "command-version",
-  "value": "git --version"
+  "executable": "git",
+  "arguments": ["--version"]
 }
 ```
 
 Security rule: verification metadata is **not arbitrary shell execution**.
 
-The runtime implementation must translate supported verification rule types into constrained operations. Catalogue text is never passed directly to a shell without a typed allowlisted interpreter.
+The runtime implementation must translate supported verification rule types into constrained operations. The executable name and argument list are validated separately and the catalogue never supplies a raw command line to a shell.
 
 For V1, `provider-query` should be preferred where reliable, with secondary verification only when needed.
 

--- a/docs/product/software-catalogue.schema.json
+++ b/docs/product/software-catalogue.schema.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agenstudio.dev/schemas/agenstart/software-catalogue.schema.json",
+  "title": "AgenStart Software Catalogue",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "catalogueVersion", "applications"],
+  "properties": {
+    "schemaVersion": {"type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$"},
+    "catalogueVersion": {"type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$"},
+    "applications": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/application"}
+    }
+  },
+  "$defs": {
+    "canonicalId": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "minLength": 2,
+      "maxLength": 80
+    },
+    "architecture": {
+      "type": "string",
+      "enum": ["x64", "arm64", "x86", "arm"]
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": {"type": "string", "enum": ["active", "deprecated", "blocked"]},
+        "replacementId": {"$ref": "#/$defs/canonicalId"},
+        "message": {"type": "string", "maxLength": 300}
+      }
+    },
+    "profileRecommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "level", "reasonKey"],
+      "properties": {
+        "profile": {
+          "type": "string",
+          "enum": ["personal", "development", "business", "creation", "training"]
+        },
+        "level": {
+          "type": "string",
+          "enum": ["essential", "recommended", "optional"]
+        },
+        "reasonKey": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+        }
+      }
+    },
+    "capabilityRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "minRamMiB": {"type": "integer", "minimum": 0},
+        "minFreeStorageMiB": {"type": "integer", "minimum": 0},
+        "gpuRequired": {"type": "boolean"},
+        "architectures": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/architecture"}
+        }
+      }
+    },
+    "platformSupport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "status", "architectures"],
+      "properties": {
+        "platform": {"type": "string", "enum": ["windows", "macos", "linux"]},
+        "status": {"type": "string", "enum": ["supported", "planned", "unsupported"]},
+        "minOsVersion": {"type": "string", "maxLength": 40},
+        "architectures": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/architecture"}
+        }
+      }
+    },
+    "wingetProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "type", "packageId", "source"],
+      "properties": {
+        "platform": {"const": "windows"},
+        "type": {"const": "winget"},
+        "packageId": {"type": "string", "minLength": 2, "maxLength": 150},
+        "source": {"type": "string", "enum": ["winget", "msstore"]},
+        "scopePreference": {"type": "string", "enum": ["user", "machine", "any"]},
+        "installerTypePreference": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["appx", "burn", "exe", "font", "inno", "msi", "msix", "msstore", "nullsoft", "portable", "wix", "zip"]
+          }
+        }
+      }
+    },
+    "homebrewProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "type", "token"],
+      "properties": {
+        "platform": {"const": "macos"},
+        "type": {"type": "string", "enum": ["homebrew-formula", "homebrew-cask"]},
+        "token": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9@+._-]*$",
+          "maxLength": 120
+        }
+      }
+    },
+    "provider": {
+      "oneOf": [
+        {"$ref": "#/$defs/wingetProvider"},
+        {"$ref": "#/$defs/homebrewProvider"}
+      ]
+    },
+    "verificationRule": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["platform", "type"],
+          "properties": {
+            "platform": {"type": "string", "enum": ["windows", "macos", "linux"]},
+            "type": {"const": "provider-query"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["platform", "type", "value"],
+          "properties": {
+            "platform": {"type": "string", "enum": ["windows", "macos", "linux"]},
+            "type": {"type": "string", "enum": ["registry-display-name", "executable-path", "bundle-id"]},
+            "value": {"type": "string", "minLength": 1, "maxLength": 300}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["platform", "type", "executable", "arguments"],
+          "properties": {
+            "platform": {"type": "string", "enum": ["windows", "macos", "linux"]},
+            "type": {"const": "command-version"},
+            "executable": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9._+-]+$",
+              "maxLength": 100
+            },
+            "arguments": {
+              "type": "array",
+              "maxItems": 5,
+              "items": {"type": "string", "maxLength": 100}
+            }
+          }
+        }
+      ]
+    },
+    "relationList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/canonicalId"}
+    },
+    "curation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["homepage", "license", "trust"],
+      "properties": {
+        "homepage": {"type": "string", "format": "uri"},
+        "license": {"type": "string", "maxLength": 120},
+        "trust": {"type": "string", "enum": ["official-publisher", "trusted-community"]},
+        "notes": {"type": "string", "maxLength": 500}
+      }
+    },
+    "application": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "name", "publisher", "description", "categories", "tags",
+        "lifecycle", "recommendations", "requirements", "platformSupport",
+        "providers", "verification", "dependencies", "conflicts", "curation"
+      ],
+      "properties": {
+        "id": {"$ref": "#/$defs/canonicalId"},
+        "name": {"type": "string", "minLength": 1, "maxLength": 120},
+        "publisher": {"type": "string", "minLength": 1, "maxLength": 120},
+        "description": {"type": "string", "minLength": 1, "maxLength": 500},
+        "categories": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["browser", "communication", "development", "design", "documents", "education", "media", "productivity", "security", "system", "utilities"]
+          }
+        },
+        "tags": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+            "maxLength": 40
+          }
+        },
+        "lifecycle": {"$ref": "#/$defs/lifecycle"},
+        "recommendations": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/profileRecommendation"}
+        },
+        "requirements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minimum", "recommended"],
+          "properties": {
+            "minimum": {"$ref": "#/$defs/capabilityRequirements"},
+            "recommended": {"$ref": "#/$defs/capabilityRequirements"}
+          }
+        },
+        "platformSupport": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/platformSupport"}
+        },
+        "providers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/provider"}
+        },
+        "verification": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/verificationRule"}
+        },
+        "dependencies": {"$ref": "#/$defs/relationList"},
+        "conflicts": {"$ref": "#/$defs/relationList"},
+        "curation": {"$ref": "#/$defs/curation"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Defines the versioned software-catalogue contract that will drive AgenStart recommendations, installation planning and future cross-platform support.

### Added
- `docs/product/software-catalogue.md`
- `docs/product/software-catalogue.schema.json`
- `docs/product/catalogue.fixtures.json`

### Key decisions
- AgenStart owns a stable canonical application ID independent of package managers
- product metadata is separated from provider metadata
- Windows provider mappings use exact WinGet package IDs + explicit source
- macOS is already modeled through future Homebrew Formula/Cask provider references
- dependencies/conflicts reference AgenStart canonical IDs only
- platform support is independent from provider availability
- lifecycle supports `active`, `deprecated` and fail-closed `blocked` states
- recommendation metadata remains explainable through stable reason keys
- verification uses typed strategies; the catalogue never contains arbitrary shell command strings
- schema and catalogue contents have independent versions
- invalid/stale catalogue data fails closed

### Representative fixtures
The contract includes 8 fixture applications: Git, Visual Studio Code, Firefox, VLC, 7-Zip, OBS Studio, Microsoft PowerToys and Docker Desktop.

### Provider rationale
WinGet package manifests use stable PackageIdentifiers and allow architecture/installer/source selection, while Homebrew Casks/Formulas expose their own tokens and platform constraints. AgenStart normalizes these behind its own domain contract instead of leaking provider concepts into recommendation logic.

Closes #3 once merged.