### PR TITLE
ci: automate GitHub Project metadata and lifecycle

### DIFF
--- a/.github/project-config.json
+++ b/.github/project-config.json
@@ -1,0 +1,47 @@
+{
+  "project": {
+    "owner": "EagleFox31",
+    "title": "AgenStart Product Development"
+  },
+  "fields": {
+    "status": "Status",
+    "priority": "Priority",
+    "workType": "Work type",
+    "phase": "Phase",
+    "size": "Size"
+  },
+  "statusTransitions": {
+    "issueOpened": "Backlog",
+    "issueReopened": "Backlog",
+    "issueClosed": "Done",
+    "draftPullRequest": "In Progress",
+    "pullRequestReady": "Review",
+    "pullRequestMerged": "Done"
+  },
+  "workTypeByTitlePrefix": {
+    "[Foundation]": "Engineering",
+    "[Engineering]": "Engineering",
+    "[Feature]": "Feature",
+    "[UX]": "UX",
+    "[Security]": "Security",
+    "[Quality]": "Quality",
+    "[Documentation]": "Documentation",
+    "[Product]": "Product",
+    "[Bug]": "Bug"
+  },
+  "issueOverrides": {
+    "1": { "priority": "P0", "workType": "Engineering", "phase": "Foundation", "size": "M" },
+    "2": { "priority": "P1", "workType": "Engineering", "phase": "Foundation", "size": "M" },
+    "3": { "priority": "P1", "workType": "Engineering", "phase": "Foundation", "size": "M" },
+    "4": { "priority": "P1", "workType": "Engineering", "phase": "Installation", "size": "L" },
+    "5": { "priority": "P1", "workType": "Feature", "phase": "Machine Intelligence", "size": "L" },
+    "6": { "priority": "P1", "workType": "Feature", "phase": "Recommendations", "size": "L" },
+    "7": { "priority": "P0", "workType": "Feature", "phase": "Installation", "size": "XL" },
+    "8": { "priority": "P1", "workType": "UX", "phase": "Desktop MVP", "size": "XL" },
+    "9": { "priority": "P2", "workType": "Feature", "phase": "Reproducible Setup", "size": "M" },
+    "10": { "priority": "P1", "workType": "Engineering", "phase": "Release", "size": "M" },
+    "11": { "priority": "P0", "workType": "Security", "phase": "Foundation", "size": "L" },
+    "15": { "priority": "P2", "workType": "Product", "phase": "Foundation", "size": "L" },
+    "16": { "priority": "P1", "workType": "Engineering", "phase": "Foundation", "size": "M" }
+  }
+}

--- a/.github/scripts/project-automation-pr.mjs
+++ b/.github/scripts/project-automation-pr.mjs
@@ -1,0 +1,4 @@
+// pull_request_target is used so PROJECT_TOKEN is never exposed to untrusted PR code.
+// The main automation script expects the logical event name `pull_request`.
+process.env.GITHUB_EVENT_NAME = 'pull_request';
+await import('./project-automation.mjs');

--- a/.github/scripts/project-automation.mjs
+++ b/.github/scripts/project-automation.mjs
@@ -1,0 +1,431 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const token = process.env.PROJECT_TOKEN;
+const repositoryFullName = process.env.GITHUB_REPOSITORY;
+const eventName = process.env.GITHUB_EVENT_NAME;
+const eventPath = process.env.GITHUB_EVENT_PATH;
+const manualIssueNumber = process.env.MANUAL_ISSUE_NUMBER?.trim();
+
+if (!token) {
+  throw new Error('PROJECT_TOKEN is not available. Add it as a repository Actions secret.');
+}
+
+if (!repositoryFullName) {
+  throw new Error('GITHUB_REPOSITORY is not available.');
+}
+
+const configPath = path.resolve('.github/project-config.json');
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+const event = eventPath && fs.existsSync(eventPath)
+  ? JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+  : {};
+
+const [repositoryOwner, repositoryName] = repositoryFullName.split('/');
+
+async function graphql(query, variables = {}) {
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'AgenStart-Project-Automation'
+    },
+    body: JSON.stringify({ query, variables })
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+
+  if (payload.errors?.length) {
+    const messages = payload.errors.map((error) => error.message).join(' | ');
+    throw new Error(`GitHub GraphQL error: ${messages}`);
+  }
+
+  return payload.data;
+}
+
+function normalize(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function parseProjectMetadata(body = '') {
+  const match = body.match(/<!--\s*agenstart-project\s*([\s\S]*?)-->/i);
+  if (!match) return {};
+
+  const metadata = {};
+
+  for (const rawLine of match[1].split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const separator = line.indexOf(':');
+    if (separator < 1) continue;
+
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+
+    if (['priority', 'workType', 'phase', 'size'].includes(key) && value) {
+      metadata[key] = value;
+    }
+  }
+
+  return metadata;
+}
+
+function inferWorkType(title = '') {
+  for (const [prefix, workType] of Object.entries(config.workTypeByTitlePrefix ?? {})) {
+    if (title.startsWith(prefix)) return workType;
+  }
+  return undefined;
+}
+
+function issueMetadata(issue) {
+  const inferred = { workType: inferWorkType(issue.title) };
+  const override = config.issueOverrides?.[String(issue.number)] ?? {};
+  const embedded = parseProjectMetadata(issue.body ?? '');
+
+  return Object.fromEntries(
+    Object.entries({ ...inferred, ...override, ...embedded })
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+  );
+}
+
+async function findProject() {
+  const query = `
+    query ProjectByOwner($login: String!) {
+      user(login: $login) {
+        projectsV2(first: 100) {
+          nodes {
+            id
+            number
+            title
+            fields(first: 100) {
+              nodes {
+                __typename
+                ... on ProjectV2Field {
+                  id
+                  name
+                }
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                  options {
+                    id
+                    name
+                  }
+                }
+                ... on ProjectV2IterationField {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+      organization(login: $login) {
+        projectsV2(first: 100) {
+          nodes {
+            id
+            number
+            title
+            fields(first: 100) {
+              nodes {
+                __typename
+                ... on ProjectV2Field {
+                  id
+                  name
+                }
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                  options {
+                    id
+                    name
+                  }
+                }
+                ... on ProjectV2IterationField {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await graphql(query, { login: config.project.owner });
+  const projects = [
+    ...(data.user?.projectsV2?.nodes ?? []),
+    ...(data.organization?.projectsV2?.nodes ?? [])
+  ];
+
+  const project = projects.find((candidate) => candidate.title === config.project.title);
+
+  if (!project) {
+    const visible = projects.map((candidate) => candidate.title).join(', ') || '(none visible)';
+    throw new Error(
+      `Project "${config.project.title}" was not found for ${config.project.owner}. Visible projects: ${visible}`
+    );
+  }
+
+  console.log(`Resolved Project #${project.number}: ${project.title}`);
+  return project;
+}
+
+async function findProjectItem(projectId, contentId) {
+  const query = `
+    query FindProjectItem($projectId: ID!, $after: String) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100, after: $after) {
+            nodes {
+              id
+              content {
+                ... on Issue { id }
+                ... on PullRequest { id }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  let after = null;
+
+  do {
+    const data = await graphql(query, { projectId, after });
+    const connection = data.node?.items;
+
+    if (!connection) {
+      throw new Error('Unable to read Project items. Check PROJECT_TOKEN project permissions.');
+    }
+
+    const match = connection.nodes.find((item) => item.content?.id === contentId);
+    if (match) return match.id;
+
+    if (!connection.pageInfo.hasNextPage) break;
+    after = connection.pageInfo.endCursor;
+  } while (after);
+
+  return null;
+}
+
+async function ensureProjectItem(projectId, contentId) {
+  const existingItemId = await findProjectItem(projectId, contentId);
+  if (existingItemId) {
+    return { itemId: existingItemId, added: false };
+  }
+
+  const mutation = `
+    mutation AddProjectItem($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }
+  `;
+
+  const data = await graphql(mutation, { projectId, contentId });
+  const itemId = data.addProjectV2ItemById?.item?.id;
+
+  if (!itemId) throw new Error('GitHub did not return the newly added Project item id.');
+  return { itemId, added: true };
+}
+
+function findSingleSelectField(project, configuredName) {
+  return project.fields.nodes.find(
+    (field) => field?.name === configuredName && Array.isArray(field.options)
+  );
+}
+
+async function setSingleSelect(project, itemId, configuredFieldName, optionName) {
+  if (!configuredFieldName || !optionName) return;
+
+  const field = findSingleSelectField(project, configuredFieldName);
+  if (!field) {
+    console.warn(`Skipping missing/non-single-select Project field: ${configuredFieldName}`);
+    return;
+  }
+
+  const option = field.options.find((candidate) => normalize(candidate.name) === normalize(optionName));
+  if (!option) {
+    console.warn(
+      `Skipping ${configuredFieldName}="${optionName}" because that option does not exist. ` +
+      `Available: ${field.options.map((candidate) => candidate.name).join(', ')}`
+    );
+    return;
+  }
+
+  const mutation = `
+    mutation SetProjectField(
+      $projectId: ID!,
+      $itemId: ID!,
+      $fieldId: ID!,
+      $optionId: String!
+    ) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId,
+          itemId: $itemId,
+          fieldId: $fieldId,
+          value: { singleSelectOptionId: $optionId }
+        }
+      ) {
+        projectV2Item { id }
+      }
+    }
+  `;
+
+  await graphql(mutation, {
+    projectId: project.id,
+    itemId,
+    fieldId: field.id,
+    optionId: option.id
+  });
+
+  console.log(`Set ${configuredFieldName} → ${option.name}`);
+}
+
+async function applyIssueFields(project, issue, itemId, status) {
+  const metadata = issueMetadata(issue);
+
+  await setSingleSelect(project, itemId, config.fields.status, status);
+  await setSingleSelect(project, itemId, config.fields.priority, metadata.priority);
+  await setSingleSelect(project, itemId, config.fields.workType, metadata.workType);
+  await setSingleSelect(project, itemId, config.fields.phase, metadata.phase);
+  await setSingleSelect(project, itemId, config.fields.size, metadata.size);
+}
+
+async function loadIssue(number) {
+  const query = `
+    query RepositoryIssue($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        issue(number: $number) {
+          id
+          number
+          title
+          body
+          state
+        }
+      }
+    }
+  `;
+
+  const data = await graphql(query, {
+    owner: repositoryOwner,
+    name: repositoryName,
+    number: Number(number)
+  });
+
+  const issue = data.repository?.issue;
+  if (!issue) throw new Error(`Issue #${number} was not found in ${repositoryFullName}.`);
+  return issue;
+}
+
+async function closingIssuesForPullRequest(pullRequestId) {
+  const query = `
+    query PullRequestClosingIssues($id: ID!) {
+      node(id: $id) {
+        ... on PullRequest {
+          closingIssuesReferences(first: 50) {
+            nodes {
+              id
+              number
+              title
+              body
+              state
+              repository { nameWithOwner }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await graphql(query, { id: pullRequestId });
+  return (data.node?.closingIssuesReferences?.nodes ?? [])
+    .filter((issue) => issue.repository?.nameWithOwner === repositoryFullName);
+}
+
+function issueStatusForAction(action) {
+  switch (action) {
+    case 'opened': return config.statusTransitions.issueOpened;
+    case 'reopened': return config.statusTransitions.issueReopened;
+    case 'closed': return config.statusTransitions.issueClosed;
+    default: return undefined;
+  }
+}
+
+async function handleIssueEvent(project) {
+  const issue = event.issue;
+  if (!issue?.node_id) throw new Error('Issue event does not contain issue.node_id.');
+
+  const { itemId } = await ensureProjectItem(project.id, issue.node_id);
+  const status = issueStatusForAction(event.action);
+  await applyIssueFields(project, issue, itemId, status);
+  console.log(`Synced Issue #${issue.number}: ${issue.title}`);
+}
+
+async function handleManualIssue(project) {
+  const issue = await loadIssue(manualIssueNumber);
+  const { itemId, added } = await ensureProjectItem(project.id, issue.id);
+  const status = added
+    ? (issue.state === 'CLOSED' ? config.statusTransitions.issueClosed : config.statusTransitions.issueOpened)
+    : undefined;
+
+  await applyIssueFields(project, issue, itemId, status);
+  console.log(`Manually synced Issue #${issue.number}: ${issue.title}`);
+}
+
+async function handlePullRequestEvent(project) {
+  const pullRequest = event.pull_request;
+  if (!pullRequest?.node_id) throw new Error('Pull request event does not contain pull_request.node_id.');
+
+  const issues = await closingIssuesForPullRequest(pullRequest.node_id);
+  if (!issues.length) {
+    console.log('No linked closing issues found for this pull request. Nothing to update.');
+    return;
+  }
+
+  let targetStatus;
+
+  if (event.action === 'closed' && pullRequest.merged) {
+    targetStatus = config.statusTransitions.pullRequestMerged;
+  } else if (['opened', 'reopened'].includes(event.action) && pullRequest.draft) {
+    targetStatus = config.statusTransitions.draftPullRequest;
+  } else if (['opened', 'reopened', 'ready_for_review'].includes(event.action)) {
+    targetStatus = config.statusTransitions.pullRequestReady;
+  } else {
+    console.log(`No status transition configured for PR action ${event.action}.`);
+    return;
+  }
+
+  for (const issue of issues) {
+    const { itemId } = await ensureProjectItem(project.id, issue.id);
+    await applyIssueFields(project, issue, itemId, targetStatus);
+    console.log(`PR lifecycle moved Issue #${issue.number} → ${targetStatus}`);
+  }
+}
+
+const project = await findProject();
+
+if (eventName === 'workflow_dispatch' && manualIssueNumber) {
+  await handleManualIssue(project);
+} else if (eventName === 'issues') {
+  await handleIssueEvent(project);
+} else if (eventName === 'pull_request') {
+  await handlePullRequestEvent(project);
+} else {
+  console.log(`Unsupported event ${eventName}; nothing to do.`);
+}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,57 @@
+name: Project automation
+
+on:
+  issues:
+    types: [opened, reopened, edited, closed]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, closed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to resync"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: agenstart-project-automation-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  sync-project:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout trusted default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Sync GitHub Project
+        shell: bash
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          MANUAL_ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PROJECT_TOKEN:-}" ]; then
+            echo "PROJECT_TOKEN repository secret is missing."
+            exit 1
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
+            node .github/scripts/project-automation-pr.mjs
+          else
+            node .github/scripts/project-automation.mjs
+          fi

--- a/docs/PROJECT-AUTOMATION.md
+++ b/docs/PROJECT-AUTOMATION.md
@@ -1,0 +1,241 @@
+# GitHub Project automation
+
+AgenStart automates repetitive GitHub Projects v2 metadata updates through GitHub Actions and the GraphQL API.
+
+## Purpose
+
+The automation reduces manual Project maintenance while keeping the workflow visible and version-controlled.
+
+It can:
+
+- discover the Project by owner + title;
+- add Issues to the Project;
+- resolve Project field IDs dynamically;
+- resolve single-select option IDs dynamically;
+- populate `Status`, `Priority`, `Work type`, `Phase` and `Size`;
+- infer `Work type` from title prefixes;
+- use explicit metadata embedded in an Issue body;
+- apply versioned overrides for the initial backlog;
+- move linked Issues to `In Progress`, `Review` or `Done` based on Pull Request lifecycle;
+- manually resync one Issue with `workflow_dispatch`.
+
+No Project node ID, field ID or option ID is committed to the repository.
+
+---
+
+## Required repository secret
+
+Repository secret:
+
+```text
+PROJECT_TOKEN
+```
+
+The token is expected to be a Personal Access Token that can read/write the user-owned GitHub Project.
+
+The secret must never be committed to the repository, printed in logs or placed in issue metadata.
+
+---
+
+## Project contract
+
+Configured in:
+
+```text
+.github/project-config.json
+```
+
+Expected Project title:
+
+```text
+AgenStart Product Development
+```
+
+Expected single-select fields:
+
+```text
+Status
+Priority
+Work type
+Phase
+Size
+```
+
+The automation resolves the actual GraphQL IDs at runtime from these human-readable names.
+
+If an optional field or option is absent, that field is skipped with a warning rather than guessed.
+
+---
+
+## Status transitions
+
+Current lifecycle mapping:
+
+```text
+Issue opened/reopened     → Backlog
+Draft PR opened/reopened  → In Progress
+Non-draft PR opened       → Review
+PR marked ready           → Review
+PR merged                 → Done
+Issue closed              → Done
+```
+
+Closing an unmerged Pull Request does not automatically move the Issue backwards because the correct state cannot be inferred safely.
+
+---
+
+## Linking a Pull Request to an Issue
+
+PR status automation relies on GitHub's closing-issue relationship.
+
+Use a supported closing keyword in the PR body, for example:
+
+```text
+Closes #11
+```
+
+or:
+
+```text
+Fixes #11
+```
+
+The automation queries `closingIssuesReferences`; it does not scrape arbitrary `#123` text from descriptions.
+
+---
+
+## Issue metadata
+
+For new issues, project metadata can be embedded without cluttering the rendered description:
+
+```html
+<!-- agenstart-project
+priority: P1
+workType: Engineering
+phase: Foundation
+size: M
+-->
+```
+
+Supported keys:
+
+```text
+priority
+workType
+phase
+size
+```
+
+Embedded metadata has highest precedence.
+
+Resolution order:
+
+```text
+Title-prefix inference
+        ↓
+Versioned issue override
+        ↓
+Embedded issue metadata
+```
+
+`Status` is deliberately not accepted from issue metadata. It is owned by workflow state transitions.
+
+---
+
+## Title-prefix inference
+
+Examples:
+
+```text
+[Engineering] → Engineering
+[Feature]     → Feature
+[UX]          → UX
+[Security]    → Security
+[Product]     → Product
+[Bug]         → Bug
+```
+
+`[Foundation]` currently maps to `Engineering` for the `Work type` field; `Foundation` itself is a Phase, not a work type.
+
+---
+
+## Existing backlog overrides
+
+The initial AgenStart issues predate embedded metadata, so `.github/project-config.json` contains explicit mappings for their Priority, Work type, Phase and Size.
+
+These mappings are migration/bootstrap data rather than a long-term requirement.
+
+New issues should prefer the embedded metadata block.
+
+---
+
+## Manual resync
+
+From GitHub:
+
+```text
+Actions
+→ Project automation
+→ Run workflow
+→ Issue number
+```
+
+The manual sync:
+
+- adds the Issue if missing;
+- reapplies Priority / Work type / Phase / Size;
+- preserves the current Status when the Issue is already in the Project;
+- assigns `Backlog` or `Done` only when the manual sync has to add a missing Issue.
+
+This makes manual resync safe for Issues already in `In Progress` or `Review`.
+
+---
+
+## Security model
+
+Pull Request lifecycle events use `pull_request_target`, not `pull_request`.
+
+This is intentional because `PROJECT_TOKEN` is a privileged secret.
+
+The workflow:
+
+1. executes using the trusted workflow from the default branch;
+2. checks out the trusted default branch explicitly;
+3. never checks out PR head code;
+4. runs only the automation script from the trusted default branch;
+5. gives the built-in `GITHUB_TOKEN` read-only repository permissions;
+6. uses `PROJECT_TOKEN` only for the Projects GraphQL calls.
+
+Do **not** change the PR job to checkout contributor code while `PROJECT_TOKEN` is available.
+
+---
+
+## Failure philosophy
+
+The automation does not guess missing Project configuration.
+
+Examples:
+
+- Project cannot be resolved → workflow fails clearly;
+- token cannot access Project → workflow fails clearly;
+- field exists but option is missing → warning and skip that field;
+- PR has no closing Issue reference → no status mutation;
+- unmerged PR closes → no backwards status guess.
+
+The Project is workflow assistance, not the source of truth for application behavior.
+
+---
+
+## Future AppFactory reuse
+
+The architecture intentionally separates:
+
+```text
+project-config.json
+        +
+project-automation.mjs
+        +
+project-automation.yml
+```
+
+so the same pattern can later be extracted into an AgenStudio AppFactory repository/action and reused by other products.


### PR DESCRIPTION
## Summary

Adds a privacy/security-conscious GitHub Projects v2 automation layer for the AgenStart AppFactory workflow.

### Added
- `.github/project-config.json`
- `.github/scripts/project-automation.mjs`
- `.github/scripts/project-automation-pr.mjs`
- `.github/workflows/project-automation.yml`
- `docs/PROJECT-AUTOMATION.md`

### What it automates
- discovers `AgenStart Product Development` dynamically by title
- discovers Project field and option IDs dynamically
- adds Issues to the Project
- populates `Priority`, `Work type`, `Phase`, `Size` and lifecycle `Status`
- infers Work type from title prefixes
- supports hidden per-Issue metadata for future Issues
- retains bootstrap overrides for the existing backlog
- draft PR → `In Progress`
- ready/non-draft PR → `Review`
- merged PR / closed Issue → `Done`
- manual one-Issue resync through `workflow_dispatch`

### Security
PR lifecycle automation uses `pull_request_target` and explicitly checks out the trusted default branch. It never checks out PR head code while `PROJECT_TOKEN` is available. The built-in `GITHUB_TOKEN` remains read-only.

### Important
The repository secret `PROJECT_TOKEN` must already exist and have access to the user-owned Project.

Closes #16