### PR TITLE
fix: normalize manual Project issue input

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to resync"
+        description: "Issue number to resync (e.g. 15, #15, or issue_number = 15)"
         required: true
         type: string
 
@@ -48,6 +48,19 @@ jobs:
           if [ -z "${PROJECT_TOKEN:-}" ]; then
             echo "PROJECT_TOKEN repository secret is missing."
             exit 1
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            raw_issue_number="${MANUAL_ISSUE_NUMBER:-}"
+            issue_pattern='^[[:space:]]*(issue_number[[:space:]]*=[[:space:]]*)?#?([0-9]+)[[:space:]]*$'
+
+            if [[ "$raw_issue_number" =~ $issue_pattern ]]; then
+              export MANUAL_ISSUE_NUMBER="${BASH_REMATCH[2]}"
+              echo "Manual resync target: Issue #${MANUAL_ISSUE_NUMBER}"
+            else
+              echo "Invalid issue_number input. Enter a positive issue number such as 15 or #15."
+              exit 1
+            fi
           fi
 
           if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then


### PR DESCRIPTION
## Fix

The manual `workflow_dispatch` run received the literal value `issue_number = 15`, so GraphQL was given an invalid `Int!` value.

### Changes
- normalizes accepted manual inputs before the Node script runs
- accepts `15`, `#15`, and `issue_number = 15`
- rejects ambiguous/non-numeric values with a clear error
- improves the workflow input description

### Verified root cause
The Project itself was resolved successfully; only the manual issue-number input was malformed.

After merge, rerun **Project automation** for Issue #15.