### PR TITLE
feat: implement typed WinGet package provider foundation

### DIFF
--- a/.github/workflows/package-management-tests.yml
+++ b/.github/workflows/package-management-tests.yml
@@ -1,0 +1,33 @@
+name: Package management tests
+
+on:
+  pull_request:
+    paths:
+      - "src/AgenStart.PackageManagement/**"
+      - "src/AgenStart.Platform.Windows/**"
+      - "tests/AgenStart.Platform.Windows.Tests/**"
+      - "docs/architecture/package-provider.md"
+      - ".github/workflows/package-management-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore
+        run: dotnet restore tests/AgenStart.Platform.Windows.Tests/AgenStart.Platform.Windows.Tests.csproj
+
+      - name: Test
+        run: dotnet test tests/AgenStart.Platform.Windows.Tests/AgenStart.Platform.Windows.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/docs/adr/0002-privilege-and-command-execution-boundary.md
+++ b/docs/adr/0002-privilege-and-command-execution-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0002: Privilege and command-execution boundary
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-09-03
 - Decision owners: AgenStudio / AgenStart
 - Related: #11, ADR-0001

--- a/docs/architecture/package-provider.md
+++ b/docs/architecture/package-provider.md
@@ -1,0 +1,431 @@
+# Package provider architecture
+
+## Purpose
+
+AgenStart must not couple product/application logic directly to WinGet.
+
+The package-provider boundary translates a trusted, typed provider reference into provider-specific operations while keeping canonical AgenStart application identity independent from package-manager identifiers.
+
+```text
+AgenStart catalogue / application layer
+        │
+        │ canonical application ID
+        │ + validated provider mapping
+        ▼
+IPackageProvider
+        │
+        ├── Windows → WinGetProvider
+        │
+        └── macOS   → future HomebrewProvider
+```
+
+This document defines the executable contract introduced by Issue #4.
+
+---
+
+## Projects
+
+```text
+src/
+├── AgenStart.PackageManagement
+│   └── provider-neutral contracts
+│
+└── AgenStart.Platform.Windows
+    └── WinGet adapter and Windows execution boundary
+
+tests/
+└── AgenStart.Platform.Windows.Tests
+```
+
+`AgenStart.PackageManagement` has no dependency on Avalonia, WinGet or Windows APIs.
+
+`AgenStart.Platform.Windows` depends on `AgenStart.PackageManagement` and owns the WinGet-specific translation/execution rules.
+
+---
+
+## Provider contract
+
+The V1 contract exposes three operations:
+
+```csharp
+public interface IPackageProvider
+{
+    string ProviderId { get; }
+
+    Task<PackageProviderAvailability> CheckAvailabilityAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<PackageResolutionResult> ResolveAsync(
+        ProviderPackageReference package,
+        CancellationToken cancellationToken = default);
+
+    Task<PackageOperationResult> InstallAsync(
+        PackageInstallRequest request,
+        CancellationToken cancellationToken = default);
+}
+```
+
+The interface deliberately does **not** expose:
+
+- arbitrary command execution;
+- raw CLI argument passthrough;
+- shell fragments;
+- arbitrary provider/source switching;
+- generic installer overrides.
+
+Those exclusions are security properties, not missing convenience features.
+
+---
+
+## Typed provider reference
+
+The catalogue owns canonical AgenStart identity and stores provider mappings.
+
+A provider receives a typed mapping such as:
+
+```csharp
+new ProviderPackageReference(
+    ProviderId: "winget",
+    PackageId: "Microsoft.VisualStudioCode",
+    Source: "winget",
+    ScopePreference: PackageScope.User);
+```
+
+The WinGet adapter validates the reference again before execution.
+
+For the Windows MVP, trusted source names are:
+
+```text
+winget
+msstore
+```
+
+A custom/user-added source is not trusted merely because it exists in the user's WinGet configuration.
+
+---
+
+## WinGet executable resolution
+
+AgenStart does not execute `winget` through an arbitrary `PATH` lookup.
+
+The V1 locator checks the current user's known App Execution Alias locations under:
+
+```text
+%LOCALAPPDATA%\Microsoft\WindowsApps\winget.exe
+
+%LOCALAPPDATA%\Microsoft\WindowsApps\
+Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe
+```
+
+If neither trusted alias is available, WinGet is reported as unavailable for the session.
+
+AgenStart does not crawl `Program Files\WindowsApps`, invoke PowerShell to discover WinGet, or execute another same-named binary from PATH as an automatic fallback.
+
+This is intentionally conservative and can be revisited if telemetry/support evidence shows legitimate installations are missed.
+
+---
+
+## Availability and provider version
+
+Provider availability is checked with a bounded direct process call equivalent to:
+
+```text
+winget --version
+```
+
+The result captures:
+
+- provider available/unavailable state;
+- best-effort WinGet version;
+- stable diagnostic code.
+
+Raw provider output is not the UI contract.
+
+Installed-application inventory and installed package-version reconciliation remain separate concerns handled by the installed-application workstream (#5). Issue #4 detects the provider's own version, not the complete machine software inventory.
+
+---
+
+## Exact resolution
+
+The runtime provider does not perform fuzzy search before installation.
+
+Resolution is equivalent to:
+
+```text
+winget show \
+  --id <exact-package-id> \
+  --exact \
+  --source <trusted-source> \
+  --disable-interactivity
+```
+
+A stale package mapping therefore fails closed instead of silently selecting a similarly named package.
+
+General package search may be useful for catalogue-maintenance tooling later, but it is intentionally excluded from the V1 runtime execution contract.
+
+---
+
+## Installation command
+
+The V1 command builder generates an argument vector equivalent to:
+
+```text
+winget install \
+  --id <exact-package-id> \
+  --exact \
+  --source <trusted-source> \
+  --disable-interactivity \
+  --no-upgrade
+```
+
+Optional typed additions are:
+
+```text
+--scope user|machine
+--silent
+--accept-package-agreements
+--accept-source-agreements
+```
+
+Agreement flags are added only when the request explicitly records consent.
+
+The following capabilities are not exposed through the provider:
+
+```text
+--override
+--custom
+--force
+--ignore-security-hash
+--ignore-local-archive-malware-scan
+--allow-reboot
+arbitrary local manifests
+arbitrary custom sources
+```
+
+The command builder owns provider arguments. Catalogue records never contain a complete executable command.
+
+---
+
+## Process execution boundary
+
+WinGet is launched directly through `ProcessStartInfo` with:
+
+```text
+UseShellExecute = false
+ArgumentList.Add(...)
+RedirectStandardOutput = true
+RedirectStandardError = true
+CreateNoWindow = true
+```
+
+AgenStart does not use:
+
+```text
+cmd.exe /c
+powershell.exe -Command
+raw concatenated command strings
+```
+
+Output and error streams are consumed asynchronously to avoid pipe deadlocks.
+
+Cancellation and timeout attempt to terminate the complete provider process tree and return structured `Cancelled` / `TimedOut` results.
+
+Default V1 operation budgets:
+
+```text
+availability check  8 seconds
+exact resolution   45 seconds
+installation       30 minutes
+```
+
+These values are provider policy and may become configuration after runtime evidence exists.
+
+---
+
+## Retry semantics
+
+`WinGetProvider` performs **no implicit retry**.
+
+Reasons:
+
+- retries can repeat installer side effects;
+- a package may have partially installed before the process returns failure;
+- retryability depends on the normalized failure category;
+- queue/orchestration policy belongs above the provider layer.
+
+The future installation orchestrator (#7) may retry only explicit retryable states after re-checking installed state.
+
+A retry must reuse the same trusted package ID and source unless the catalogue itself changes through a separately validated update.
+
+---
+
+## No source fallback
+
+Provider/source fallback is explicit policy.
+
+Example:
+
+```text
+catalogue mapping = Git.Git @ winget
+winget source unavailable
+        ↓
+SourceUnavailable
+```
+
+AgenStart does **not** then try:
+
+```text
+msstore
+another custom source
+fuzzy package search
+direct-download mirror
+```
+
+A different provider/source may only be attempted when the catalogue contains an explicitly trusted mapping and an upper-layer policy deliberately selects it.
+
+---
+
+## Normalized result model
+
+The UI/orchestrator consumes AgenStart states rather than WinGet HRESULTs.
+
+Initial operation states:
+
+```text
+Succeeded
+AlreadyInstalled
+NotFound
+Ambiguous
+NoApplicableInstaller
+SourceUnavailable
+AgreementRequired
+RequiresElevation
+BlockedByPolicy
+IntegrityFailure
+NetworkFailure
+RebootRequired
+CancelledByUser
+Cancelled
+TimedOut
+ProviderUnavailable
+Failed
+```
+
+Unknown WinGet return codes map to `Failed` with diagnostic code:
+
+```text
+winget.unmapped-error
+```
+
+They are never guessed into a success/retry state.
+
+The normalizer currently covers stable WinGet CLI/install error families including:
+
+- package not found / multiple matches;
+- no applicable installer;
+- missing/unavailable source;
+- package/source agreements;
+- policy blocks;
+- hash/security/integrity failures;
+- network/service failures;
+- reboot requirements;
+- user cancellation;
+- already-installed state.
+
+Reference definitions:
+
+- WinGet return codes: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+- WinGet error constants: https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerSharedLib/Public/AppInstallerErrors.h
+
+---
+
+## Elevation
+
+The main AgenStart process remains `asInvoker` and launches WinGet non-elevated.
+
+AgenStart does not create an elevated broker for ordinary WinGet installs.
+
+When the selected installer requires elevation, Windows/the installer owns the UAC flow.
+
+A WinGet result indicating that the command itself requires administrator context is normalized to:
+
+```text
+RequiresElevation
+```
+
+It is not automatically retried by relaunching AgenStart as administrator.
+
+This follows ADR-0002.
+
+---
+
+## Agreements and interactivity
+
+The provider always disables WinGet interactive prompts so a background install queue cannot stall on hidden console input.
+
+If a package/source agreement has not been accepted, the provider returns:
+
+```text
+AgreementRequired
+```
+
+An upper UI layer can then display an explicit user decision and retry with the corresponding typed consent flag.
+
+AgenStart must not infer legal consent from merely selecting an application.
+
+---
+
+## Output and privacy
+
+Provider stdout/stderr may contain paths, usernames or installer-specific details.
+
+Therefore raw provider output is not returned as the normal UI result and must not be sent directly to telemetry.
+
+The stable result contract exposes:
+
+```text
+AgenStart status
+canonical application ID
+provider/package/source identity
+native exit code
+stable diagnostic code
+safe product message
+```
+
+Future diagnostic logging must follow `docs/security/security-model.md` redaction and retention rules.
+
+---
+
+## Verification
+
+The first provider test suite proves that:
+
+- only exact package ID + source commands are built;
+- untrusted sources are rejected before process start;
+- package IDs that resemble CLI flags/command injection are rejected;
+- prohibited security-bypass flags are not generated;
+- agreement flags require explicit request values;
+- provider failures do not trigger source fallback;
+- known WinGet HRESULTs become normalized AgenStart states;
+- unknown HRESULTs fail closed;
+- cancellation/timeout override misleading native exit codes;
+- raw provider output is not copied into the structured result message.
+
+The test suite runs on Windows through `.github/workflows/package-management-tests.yml`.
+
+---
+
+## Follow-up boundaries
+
+Issue #4 does not implement:
+
+- installation queue/orchestration (#7);
+- installed application inventory (#5);
+- recommendation logic (#6);
+- UI progress surfaces (#8);
+- automatic global rollback;
+- self-update;
+- custom enterprise WinGet sources;
+- an AgenStart-owned elevated helper.
+
+These concerns build on the provider contract rather than being folded into it.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/AgenStart.PackageManagement/AgenStart.PackageManagement.csproj
+++ b/src/AgenStart.PackageManagement/AgenStart.PackageManagement.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/src/AgenStart.PackageManagement/PackageProviderContracts.cs
+++ b/src/AgenStart.PackageManagement/PackageProviderContracts.cs
@@ -55,6 +55,7 @@ public enum PackageResolutionStatus
     IntegrityFailure,
     Cancelled,
     TimedOut,
+    ProviderUnavailable,
     Failed
 }
 

--- a/src/AgenStart.PackageManagement/PackageProviderContracts.cs
+++ b/src/AgenStart.PackageManagement/PackageProviderContracts.cs
@@ -1,0 +1,116 @@
+namespace AgenStart.PackageManagement;
+
+public static class PackageProviderIds
+{
+    public const string WinGet = "winget";
+    public const string Homebrew = "homebrew";
+}
+
+public enum PackageScope
+{
+    Default = 0,
+    User = 1,
+    Machine = 2
+}
+
+public sealed record ProviderPackageReference(
+    string ProviderId,
+    string PackageId,
+    string Source,
+    PackageScope ScopePreference = PackageScope.Default);
+
+public sealed record PackageInstallRequest(
+    string ApplicationId,
+    ProviderPackageReference Package,
+    bool Silent = true,
+    bool AcceptPackageAgreements = false,
+    bool AcceptSourceAgreements = false);
+
+public enum PackageProviderAvailabilityStatus
+{
+    Available = 0,
+    UnsupportedPlatform,
+    NotInstalled,
+    Unhealthy
+}
+
+public sealed record PackageProviderAvailability(
+    PackageProviderAvailabilityStatus Status,
+    string? Version = null,
+    string? DiagnosticCode = null,
+    string? Message = null)
+{
+    public bool IsAvailable => Status == PackageProviderAvailabilityStatus.Available;
+}
+
+public enum PackageResolutionStatus
+{
+    Resolved = 0,
+    NotFound,
+    Ambiguous,
+    NoApplicableInstaller,
+    SourceUnavailable,
+    AgreementRequired,
+    BlockedByPolicy,
+    IntegrityFailure,
+    Cancelled,
+    TimedOut,
+    Failed
+}
+
+public sealed record PackageResolutionResult(
+    PackageResolutionStatus Status,
+    ProviderPackageReference Package,
+    int? NativeExitCode = null,
+    string? DiagnosticCode = null,
+    string? Message = null)
+{
+    public bool IsResolved => Status == PackageResolutionStatus.Resolved;
+}
+
+public enum PackageOperationStatus
+{
+    Succeeded = 0,
+    AlreadyInstalled,
+    NotFound,
+    Ambiguous,
+    NoApplicableInstaller,
+    SourceUnavailable,
+    AgreementRequired,
+    RequiresElevation,
+    BlockedByPolicy,
+    IntegrityFailure,
+    NetworkFailure,
+    RebootRequired,
+    CancelledByUser,
+    Cancelled,
+    TimedOut,
+    ProviderUnavailable,
+    Failed
+}
+
+public sealed record PackageOperationResult(
+    PackageOperationStatus Status,
+    string ApplicationId,
+    ProviderPackageReference Package,
+    int? NativeExitCode = null,
+    string? DiagnosticCode = null,
+    string? Message = null)
+{
+    public bool IsSuccess => Status is PackageOperationStatus.Succeeded or PackageOperationStatus.AlreadyInstalled;
+}
+
+public interface IPackageProvider
+{
+    string ProviderId { get; }
+
+    Task<PackageProviderAvailability> CheckAvailabilityAsync(CancellationToken cancellationToken = default);
+
+    Task<PackageResolutionResult> ResolveAsync(
+        ProviderPackageReference package,
+        CancellationToken cancellationToken = default);
+
+    Task<PackageOperationResult> InstallAsync(
+        PackageInstallRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/AgenStart.Platform.Windows/AgenStart.Platform.Windows.csproj
+++ b/src/AgenStart.Platform.Windows/AgenStart.Platform.Windows.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgenStart.PackageManagement\AgenStart.PackageManagement.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetCommandBuilder.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetCommandBuilder.cs
@@ -1,0 +1,119 @@
+using System.Text.RegularExpressions;
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Platform.Windows.WinGet;
+
+public sealed record WinGetCommand(IReadOnlyList<string> Arguments);
+
+public static partial class WinGetCommandBuilder
+{
+    private static readonly HashSet<string> AllowedSources = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "winget",
+        "msstore"
+    };
+
+    [GeneratedRegex("^[A-Za-z0-9][A-Za-z0-9._+-]{0,254}$", RegexOptions.CultureInvariant)]
+    private static partial Regex PackageIdPattern();
+
+    public static WinGetCommand BuildResolve(ProviderPackageReference package)
+    {
+        ValidateReference(package);
+
+        return new WinGetCommand(
+        [
+            "show",
+            "--id", package.PackageId,
+            "--exact",
+            "--source", package.Source,
+            "--disable-interactivity"
+        ]);
+    }
+
+    public static WinGetCommand BuildInstall(PackageInstallRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateApplicationId(request.ApplicationId);
+        ValidateReference(request.Package);
+
+        var arguments = new List<string>
+        {
+            "install",
+            "--id", request.Package.PackageId,
+            "--exact",
+            "--source", request.Package.Source,
+            "--disable-interactivity",
+            "--no-upgrade"
+        };
+
+        switch (request.Package.ScopePreference)
+        {
+            case PackageScope.User:
+                arguments.Add("--scope");
+                arguments.Add("user");
+                break;
+            case PackageScope.Machine:
+                arguments.Add("--scope");
+                arguments.Add("machine");
+                break;
+            case PackageScope.Default:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(request),
+                    request.Package.ScopePreference,
+                    "Unsupported package scope.");
+        }
+
+        if (request.Silent)
+        {
+            arguments.Add("--silent");
+        }
+
+        if (request.AcceptPackageAgreements)
+        {
+            arguments.Add("--accept-package-agreements");
+        }
+
+        if (request.AcceptSourceAgreements)
+        {
+            arguments.Add("--accept-source-agreements");
+        }
+
+        return new WinGetCommand(arguments);
+    }
+
+    public static void ValidateReference(ProviderPackageReference package)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        if (!string.Equals(package.ProviderId, PackageProviderIds.WinGet, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"WinGet provider cannot execute provider reference '{package.ProviderId}'.",
+                nameof(package));
+        }
+
+        if (string.IsNullOrWhiteSpace(package.PackageId) || !PackageIdPattern().IsMatch(package.PackageId))
+        {
+            throw new ArgumentException(
+                "WinGet package ID contains unsupported characters or shape.",
+                nameof(package));
+        }
+
+        if (!AllowedSources.Contains(package.Source))
+        {
+            throw new ArgumentException(
+                $"WinGet source '{package.Source}' is not trusted by the MVP provider policy.",
+                nameof(package));
+        }
+    }
+
+    private static void ValidateApplicationId(string applicationId)
+    {
+        if (string.IsNullOrWhiteSpace(applicationId))
+        {
+            throw new ArgumentException("Canonical AgenStart application ID is required.", nameof(applicationId));
+        }
+    }
+}

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetProcessRunner.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetProcessRunner.cs
@@ -1,0 +1,212 @@
+using System.Diagnostics;
+
+namespace AgenStart.Platform.Windows.WinGet;
+
+public sealed record WinGetExecutableResolution(
+    bool Found,
+    string? Path = null,
+    string? DiagnosticCode = null,
+    string? Message = null);
+
+public sealed record WinGetProcessResult(
+    bool Started,
+    int? ExitCode,
+    string StandardOutput,
+    string StandardError,
+    bool Cancelled = false,
+    bool TimedOut = false,
+    string? StartError = null);
+
+public interface IWinGetExecutableLocator
+{
+    WinGetExecutableResolution Resolve();
+}
+
+public interface IWinGetProcessRunner
+{
+    Task<WinGetProcessResult> RunAsync(
+        string executablePath,
+        IReadOnlyList<string> arguments,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class WinGetExecutableLocator : IWinGetExecutableLocator
+{
+    public WinGetExecutableResolution Resolve()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return new WinGetExecutableResolution(
+                false,
+                DiagnosticCode: "winget.unsupported-platform",
+                Message: "WinGet is only available on Windows.");
+        }
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localAppData))
+        {
+            return new WinGetExecutableResolution(
+                false,
+                DiagnosticCode: "winget.localappdata-unavailable",
+                Message: "Unable to resolve the current user's LocalAppData directory.");
+        }
+
+        var windowsApps = Path.GetFullPath(Path.Combine(localAppData, "Microsoft", "WindowsApps"));
+        var candidates = new[]
+        {
+            Path.Combine(windowsApps, "winget.exe"),
+            Path.Combine(
+                windowsApps,
+                "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe",
+                "winget.exe")
+        };
+
+        foreach (var candidate in candidates)
+        {
+            var fullPath = Path.GetFullPath(candidate);
+            if (!fullPath.StartsWith(windowsApps, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (File.Exists(fullPath))
+            {
+                return new WinGetExecutableResolution(true, fullPath);
+            }
+        }
+
+        return new WinGetExecutableResolution(
+            false,
+            DiagnosticCode: "winget.alias-not-found",
+            Message: "The trusted WinGet App Execution Alias was not found for the current user.");
+    }
+}
+
+public sealed class WinGetProcessRunner : IWinGetProcessRunner
+{
+    public async Task<WinGetProcessResult> RunAsync(
+        string executablePath,
+        IReadOnlyList<string> arguments,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executablePath);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be positive.");
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            if (!process.Start())
+            {
+                return new WinGetProcessResult(
+                    false,
+                    null,
+                    string.Empty,
+                    string.Empty,
+                    StartError: "Process.Start returned false.");
+            }
+        }
+        catch (Exception exception) when (exception is System.ComponentModel.Win32Exception or InvalidOperationException)
+        {
+            return new WinGetProcessResult(
+                false,
+                null,
+                string.Empty,
+                string.Empty,
+                StartError: exception.Message);
+        }
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts.Token);
+
+        try
+        {
+            await process.WaitForExitAsync(linkedCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKillProcessTree(process);
+
+            try
+            {
+                await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException)
+            {
+                // The process may already have terminated between checks.
+            }
+
+            var cancelled = cancellationToken.IsCancellationRequested;
+            return new WinGetProcessResult(
+                true,
+                process.HasExited ? process.ExitCode : null,
+                await ReadSafelyAsync(standardOutputTask).ConfigureAwait(false),
+                await ReadSafelyAsync(standardErrorTask).ConfigureAwait(false),
+                Cancelled: cancelled,
+                TimedOut: !cancelled);
+        }
+
+        return new WinGetProcessResult(
+            true,
+            process.ExitCode,
+            await standardOutputTask.ConfigureAwait(false),
+            await standardErrorTask.ConfigureAwait(false));
+    }
+
+    private static void TryKillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Process exited before the kill request reached it.
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Best effort. The caller still receives Cancelled/TimedOut.
+        }
+    }
+
+    private static async Task<string> ReadSafelyAsync(Task<string> readTask)
+    {
+        try
+        {
+            return await readTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetProvider.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetProvider.cs
@@ -1,0 +1,208 @@
+using System.Text.RegularExpressions;
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Platform.Windows.WinGet;
+
+public sealed partial class WinGetProvider : IPackageProvider
+{
+    private static readonly TimeSpan AvailabilityTimeout = TimeSpan.FromSeconds(8);
+    private static readonly TimeSpan ResolveTimeout = TimeSpan.FromSeconds(45);
+    private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(30);
+
+    private readonly IWinGetExecutableLocator _locator;
+    private readonly IWinGetProcessRunner _runner;
+
+    public WinGetProvider()
+        : this(new WinGetExecutableLocator(), new WinGetProcessRunner())
+    {
+    }
+
+    public WinGetProvider(
+        IWinGetExecutableLocator locator,
+        IWinGetProcessRunner runner)
+    {
+        _locator = locator ?? throw new ArgumentNullException(nameof(locator));
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+    }
+
+    public string ProviderId => PackageProviderIds.WinGet;
+
+    public async Task<PackageProviderAvailability> CheckAvailabilityAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var executable = _locator.Resolve();
+        if (!executable.Found || string.IsNullOrWhiteSpace(executable.Path))
+        {
+            return new PackageProviderAvailability(
+                OperatingSystem.IsWindows()
+                    ? PackageProviderAvailabilityStatus.NotInstalled
+                    : PackageProviderAvailabilityStatus.UnsupportedPlatform,
+                DiagnosticCode: executable.DiagnosticCode,
+                Message: executable.Message);
+        }
+
+        var processResult = await _runner.RunAsync(
+            executable.Path,
+            ["--version"],
+            AvailabilityTimeout,
+            cancellationToken).ConfigureAwait(false);
+
+        if (processResult.Cancelled)
+        {
+            return new PackageProviderAvailability(
+                PackageProviderAvailabilityStatus.Unhealthy,
+                DiagnosticCode: "winget.availability-cancelled",
+                Message: "WinGet availability check was cancelled.");
+        }
+
+        if (processResult.TimedOut)
+        {
+            return new PackageProviderAvailability(
+                PackageProviderAvailabilityStatus.Unhealthy,
+                DiagnosticCode: "winget.availability-timeout",
+                Message: "WinGet did not respond before the availability timeout.");
+        }
+
+        if (!processResult.Started || processResult.ExitCode != 0)
+        {
+            return new PackageProviderAvailability(
+                PackageProviderAvailabilityStatus.Unhealthy,
+                DiagnosticCode: "winget.availability-failed",
+                Message: "WinGet could not be executed successfully.");
+        }
+
+        var version = ParseVersion(processResult.StandardOutput);
+        return new PackageProviderAvailability(
+            PackageProviderAvailabilityStatus.Available,
+            Version: version,
+            DiagnosticCode: version is null ? "winget.version-unparsed" : null);
+    }
+
+    public async Task<PackageResolutionResult> ResolveAsync(
+        ProviderPackageReference package,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        WinGetCommand command;
+        try
+        {
+            command = WinGetCommandBuilder.BuildResolve(package);
+        }
+        catch (ArgumentException exception)
+        {
+            return new PackageResolutionResult(
+                PackageResolutionStatus.Failed,
+                package,
+                DiagnosticCode: "winget.invalid-package-reference",
+                Message: exception.Message);
+        }
+
+        var executable = _locator.Resolve();
+        if (!executable.Found || string.IsNullOrWhiteSpace(executable.Path))
+        {
+            return new PackageResolutionResult(
+                PackageResolutionStatus.ProviderUnavailable,
+                package,
+                DiagnosticCode: executable.DiagnosticCode,
+                Message: executable.Message);
+        }
+
+        var processResult = await _runner.RunAsync(
+            executable.Path,
+            command.Arguments,
+            ResolveTimeout,
+            cancellationToken).ConfigureAwait(false);
+
+        var normalized = WinGetResultNormalizer.Normalize(processResult);
+        return new PackageResolutionResult(
+            WinGetResultNormalizer.ToResolutionStatus(normalized.Status),
+            package,
+            processResult.ExitCode,
+            normalized.DiagnosticCode,
+            MessageFor(normalized.Status));
+    }
+
+    public async Task<PackageOperationResult> InstallAsync(
+        PackageInstallRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        WinGetCommand command;
+        try
+        {
+            command = WinGetCommandBuilder.BuildInstall(request);
+        }
+        catch (ArgumentException exception)
+        {
+            return new PackageOperationResult(
+                PackageOperationStatus.Failed,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.invalid-install-request",
+                Message: exception.Message);
+        }
+
+        var executable = _locator.Resolve();
+        if (!executable.Found || string.IsNullOrWhiteSpace(executable.Path))
+        {
+            return new PackageOperationResult(
+                PackageOperationStatus.ProviderUnavailable,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: executable.DiagnosticCode,
+                Message: executable.Message);
+        }
+
+        var processResult = await _runner.RunAsync(
+            executable.Path,
+            command.Arguments,
+            InstallTimeout,
+            cancellationToken).ConfigureAwait(false);
+
+        var normalized = WinGetResultNormalizer.Normalize(processResult);
+        return new PackageOperationResult(
+            normalized.Status,
+            request.ApplicationId,
+            request.Package,
+            processResult.ExitCode,
+            normalized.DiagnosticCode,
+            MessageFor(normalized.Status));
+    }
+
+    [GeneratedRegex(@"\bv?(\d+(?:\.\d+){1,3}(?:[-+][A-Za-z0-9.-]+)?)\b", RegexOptions.CultureInvariant)]
+    private static partial Regex VersionPattern();
+
+    private static string? ParseVersion(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return null;
+        }
+
+        var match = VersionPattern().Match(output);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private static string MessageFor(PackageOperationStatus status) => status switch
+    {
+        PackageOperationStatus.Succeeded => "WinGet completed successfully.",
+        PackageOperationStatus.AlreadyInstalled => "The package is already installed.",
+        PackageOperationStatus.NotFound => "The exact package mapping was not found in the configured source.",
+        PackageOperationStatus.Ambiguous => "WinGet returned more than one package for an operation that requires an exact match.",
+        PackageOperationStatus.NoApplicableInstaller => "The package exists but has no applicable installer for this machine.",
+        PackageOperationStatus.SourceUnavailable => "The configured WinGet source is unavailable.",
+        PackageOperationStatus.AgreementRequired => "A package or source agreement must be accepted explicitly before retrying.",
+        PackageOperationStatus.RequiresElevation => "The operation requires elevation that WinGet could not obtain through the normal installer flow.",
+        PackageOperationStatus.BlockedByPolicy => "Windows or organization policy blocked the package operation.",
+        PackageOperationStatus.IntegrityFailure => "WinGet rejected the operation because an integrity or security check failed.",
+        PackageOperationStatus.NetworkFailure => "The package operation failed because the network or provider service was unavailable.",
+        PackageOperationStatus.RebootRequired => "The installer requires a reboot to continue or finish.",
+        PackageOperationStatus.CancelledByUser => "The user cancelled the installer or authentication flow.",
+        PackageOperationStatus.Cancelled => "The package operation was cancelled.",
+        PackageOperationStatus.TimedOut => "The package operation exceeded its timeout.",
+        PackageOperationStatus.ProviderUnavailable => "WinGet is unavailable for the current user session.",
+        _ => "WinGet returned an unclassified failure."
+    };
+}

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetResultNormalizer.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetResultNormalizer.cs
@@ -1,0 +1,103 @@
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Platform.Windows.WinGet;
+
+public sealed record NormalizedWinGetResult(
+    PackageOperationStatus Status,
+    string DiagnosticCode);
+
+public static class WinGetResultNormalizer
+{
+    private const int Success = 0;
+
+    private static readonly IReadOnlyDictionary<int, NormalizedWinGetResult> KnownResults =
+        new Dictionary<int, NormalizedWinGetResult>
+        {
+            [HResult(0x8A150061)] = new(PackageOperationStatus.AlreadyInstalled, "winget.package-already-installed"),
+            [HResult(0x8A15010D)] = new(PackageOperationStatus.AlreadyInstalled, "winget.install-already-installed"),
+
+            [HResult(0x8A150014)] = new(PackageOperationStatus.NotFound, "winget.no-applications-found"),
+            [HResult(0x8A150016)] = new(PackageOperationStatus.Ambiguous, "winget.multiple-applications-found"),
+            [HResult(0x8A150010)] = new(PackageOperationStatus.NoApplicableInstaller, "winget.no-applicable-installer"),
+
+            [HResult(0x8A150012)] = new(PackageOperationStatus.SourceUnavailable, "winget.source-does-not-exist"),
+            [HResult(0x8A150015)] = new(PackageOperationStatus.SourceUnavailable, "winget.no-sources-defined"),
+            [HResult(0x8A150045)] = new(PackageOperationStatus.SourceUnavailable, "winget.source-open-failed"),
+            [HResult(0x8A15004B)] = new(PackageOperationStatus.SourceUnavailable, "winget.failed-to-open-sources"),
+
+            [HResult(0x8A150041)] = new(PackageOperationStatus.AgreementRequired, "winget.package-agreement-required"),
+            [HResult(0x8A150046)] = new(PackageOperationStatus.AgreementRequired, "winget.source-agreement-required"),
+
+            [HResult(0x8A150019)] = new(PackageOperationStatus.RequiresElevation, "winget.command-requires-admin"),
+
+            [HResult(0x8A15001B)] = new(PackageOperationStatus.BlockedByPolicy, "winget.msstore-blocked-by-policy"),
+            [HResult(0x8A15001C)] = new(PackageOperationStatus.BlockedByPolicy, "winget.msstore-app-blocked-by-policy"),
+            [HResult(0x8A15003A)] = new(PackageOperationStatus.BlockedByPolicy, "winget.blocked-by-policy"),
+            [HResult(0x8A15010F)] = new(PackageOperationStatus.BlockedByPolicy, "winget.install-blocked-by-policy"),
+
+            [HResult(0x8A150011)] = new(PackageOperationStatus.IntegrityFailure, "winget.installer-hash-mismatch"),
+            [HResult(0x8A15002D)] = new(PackageOperationStatus.IntegrityFailure, "winget.installer-security-check-failed"),
+            [HResult(0x8A15003F)] = new(PackageOperationStatus.IntegrityFailure, "winget.source-integrity-failure"),
+            [HResult(0x8A15005E)] = new(PackageOperationStatus.IntegrityFailure, "winget.pinned-certificate-mismatch"),
+            [HResult(0x8A150060)] = new(PackageOperationStatus.IntegrityFailure, "winget.archive-scan-failed"),
+
+            [HResult(0x8A150008)] = new(PackageOperationStatus.NetworkFailure, "winget.download-failed"),
+            [HResult(0x8A15006D)] = new(PackageOperationStatus.NetworkFailure, "winget.service-unavailable"),
+            [HResult(0x8A150107)] = new(PackageOperationStatus.NetworkFailure, "winget.install-no-network"),
+
+            [HResult(0x8A150109)] = new(PackageOperationStatus.RebootRequired, "winget.reboot-required-to-finish"),
+            [HResult(0x8A15010A)] = new(PackageOperationStatus.RebootRequired, "winget.reboot-required-for-install"),
+            [HResult(0x8A15010B)] = new(PackageOperationStatus.RebootRequired, "winget.reboot-initiated"),
+
+            [HResult(0x8A15010C)] = new(PackageOperationStatus.CancelledByUser, "winget.install-cancelled-by-user"),
+            [HResult(0x8A150077)] = new(PackageOperationStatus.CancelledByUser, "winget.authentication-cancelled-by-user"),
+            [HResult(0x8A150005)] = new(PackageOperationStatus.Cancelled, "winget.ctrl-signal-received"),
+            [HResult(0x8A15006A)] = new(PackageOperationStatus.Cancelled, "winget.application-termination-received")
+        };
+
+    public static NormalizedWinGetResult Normalize(WinGetProcessResult processResult)
+    {
+        ArgumentNullException.ThrowIfNull(processResult);
+
+        if (processResult.Cancelled)
+        {
+            return new NormalizedWinGetResult(PackageOperationStatus.Cancelled, "provider.cancelled");
+        }
+
+        if (processResult.TimedOut)
+        {
+            return new NormalizedWinGetResult(PackageOperationStatus.TimedOut, "provider.timed-out");
+        }
+
+        if (!processResult.Started || processResult.ExitCode is null)
+        {
+            return new NormalizedWinGetResult(PackageOperationStatus.ProviderUnavailable, "winget.process-start-failed");
+        }
+
+        if (processResult.ExitCode == Success)
+        {
+            return new NormalizedWinGetResult(PackageOperationStatus.Succeeded, "winget.success");
+        }
+
+        return KnownResults.TryGetValue(processResult.ExitCode.Value, out var result)
+            ? result
+            : new NormalizedWinGetResult(PackageOperationStatus.Failed, "winget.unmapped-error");
+    }
+
+    public static PackageResolutionStatus ToResolutionStatus(PackageOperationStatus status) => status switch
+    {
+        PackageOperationStatus.Succeeded => PackageResolutionStatus.Resolved,
+        PackageOperationStatus.NotFound => PackageResolutionStatus.NotFound,
+        PackageOperationStatus.Ambiguous => PackageResolutionStatus.Ambiguous,
+        PackageOperationStatus.NoApplicableInstaller => PackageResolutionStatus.NoApplicableInstaller,
+        PackageOperationStatus.SourceUnavailable or PackageOperationStatus.ProviderUnavailable => PackageResolutionStatus.SourceUnavailable,
+        PackageOperationStatus.AgreementRequired => PackageResolutionStatus.AgreementRequired,
+        PackageOperationStatus.BlockedByPolicy => PackageResolutionStatus.BlockedByPolicy,
+        PackageOperationStatus.IntegrityFailure => PackageResolutionStatus.IntegrityFailure,
+        PackageOperationStatus.Cancelled or PackageOperationStatus.CancelledByUser => PackageResolutionStatus.Cancelled,
+        PackageOperationStatus.TimedOut => PackageResolutionStatus.TimedOut,
+        _ => PackageResolutionStatus.Failed
+    };
+
+    private static int HResult(uint value) => unchecked((int)value);
+}

--- a/tests/AgenStart.Platform.Windows.Tests/AgenStart.Platform.Windows.Tests.csproj
+++ b/tests/AgenStart.Platform.Windows.Tests/AgenStart.Platform.Windows.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgenStart.Platform.Windows\AgenStart.Platform.Windows.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/AgenStart.Platform.Windows.Tests/GlobalUsings.cs
+++ b/tests/AgenStart.Platform.Windows.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/AgenStart.Platform.Windows.Tests/WinGetCommandBuilderTests.cs
+++ b/tests/AgenStart.Platform.Windows.Tests/WinGetCommandBuilderTests.cs
@@ -1,0 +1,122 @@
+using AgenStart.PackageManagement;
+using AgenStart.Platform.Windows.WinGet;
+
+namespace AgenStart.Platform.Windows.Tests;
+
+public sealed class WinGetCommandBuilderTests
+{
+    [Fact]
+    public void BuildInstall_UsesExactTrustedPackageAndNoUpgrade()
+    {
+        var request = new PackageInstallRequest(
+            "visual-studio-code",
+            new ProviderPackageReference(
+                PackageProviderIds.WinGet,
+                "Microsoft.VisualStudioCode",
+                "winget",
+                PackageScope.User));
+
+        var command = WinGetCommandBuilder.BuildInstall(request);
+
+        Assert.Equal(
+        [
+            "install",
+            "--id", "Microsoft.VisualStudioCode",
+            "--exact",
+            "--source", "winget",
+            "--disable-interactivity",
+            "--no-upgrade",
+            "--scope", "user",
+            "--silent"
+        ],
+        command.Arguments);
+    }
+
+    [Fact]
+    public void BuildInstall_AddsAgreementFlagsOnlyAfterExplicitConsent()
+    {
+        var request = new PackageInstallRequest(
+            "powertoys",
+            new ProviderPackageReference(
+                PackageProviderIds.WinGet,
+                "Microsoft.PowerToys",
+                "winget"),
+            AcceptPackageAgreements: true,
+            AcceptSourceAgreements: true);
+
+        var command = WinGetCommandBuilder.BuildInstall(request);
+
+        Assert.Contains("--accept-package-agreements", command.Arguments);
+        Assert.Contains("--accept-source-agreements", command.Arguments);
+    }
+
+    [Fact]
+    public void BuildInstall_DoesNotExposeSecurityBypassArguments()
+    {
+        var request = new PackageInstallRequest(
+            "git",
+            new ProviderPackageReference(PackageProviderIds.WinGet, "Git.Git", "winget"));
+
+        var command = WinGetCommandBuilder.BuildInstall(request);
+
+        var prohibited = new[]
+        {
+            "--override",
+            "--custom",
+            "--force",
+            "--ignore-security-hash",
+            "--ignore-local-archive-malware-scan",
+            "--allow-reboot"
+        };
+
+        Assert.DoesNotContain(command.Arguments, argument => prohibited.Contains(argument));
+    }
+
+    [Theory]
+    [InlineData("--override")]
+    [InlineData("Microsoft.VisualStudioCode --force")]
+    [InlineData("Microsoft.VisualStudioCode;calc.exe")]
+    [InlineData("")]
+    public void BuildInstall_RejectsUnsafePackageIds(string packageId)
+    {
+        var request = new PackageInstallRequest(
+            "visual-studio-code",
+            new ProviderPackageReference(PackageProviderIds.WinGet, packageId, "winget"));
+
+        Assert.Throws<ArgumentException>(() => WinGetCommandBuilder.BuildInstall(request));
+    }
+
+    [Theory]
+    [InlineData("evil-source")]
+    [InlineData("winget-preview")]
+    [InlineData("https://example.test")]
+    public void BuildInstall_RejectsUntrustedSources(string source)
+    {
+        var request = new PackageInstallRequest(
+            "git",
+            new ProviderPackageReference(PackageProviderIds.WinGet, "Git.Git", source));
+
+        Assert.Throws<ArgumentException>(() => WinGetCommandBuilder.BuildInstall(request));
+    }
+
+    [Fact]
+    public void BuildResolve_UsesExactIdAndConfiguredSource()
+    {
+        var package = new ProviderPackageReference(
+            PackageProviderIds.WinGet,
+            "VideoLAN.VLC",
+            "winget");
+
+        var command = WinGetCommandBuilder.BuildResolve(package);
+
+        Assert.Equal(
+        [
+            "show",
+            "--id", "VideoLAN.VLC",
+            "--exact",
+            "--source", "winget",
+            "--disable-interactivity"
+        ],
+        command.Arguments);
+    }
+}

--- a/tests/AgenStart.Platform.Windows.Tests/WinGetProviderTests.cs
+++ b/tests/AgenStart.Platform.Windows.Tests/WinGetProviderTests.cs
@@ -21,7 +21,9 @@ public sealed class WinGetProviderTests
             "Microsoft.PowerToys",
             "winget");
 
-        var result = await provider.ResolveAsync(package);
+        var result = await provider.ResolveAsync(
+            package,
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(PackageResolutionStatus.SourceUnavailable, result.Status);
         Assert.Single(runner.Calls);
@@ -42,7 +44,9 @@ public sealed class WinGetProviderTests
                 "Git.Git --override",
                 "winget"));
 
-        var result = await provider.InstallAsync(request);
+        var result = await provider.InstallAsync(
+            request,
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(PackageOperationStatus.Failed, result.Status);
         Assert.Equal("winget.invalid-install-request", result.DiagnosticCode);
@@ -64,7 +68,9 @@ public sealed class WinGetProviderTests
             "git",
             new ProviderPackageReference(PackageProviderIds.WinGet, "Git.Git", "winget"));
 
-        var result = await provider.InstallAsync(request);
+        var result = await provider.InstallAsync(
+            request,
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(PackageOperationStatus.IntegrityFailure, result.Status);
         Assert.DoesNotContain("SensitiveUser", result.Message ?? string.Empty, StringComparison.OrdinalIgnoreCase);

--- a/tests/AgenStart.Platform.Windows.Tests/WinGetProviderTests.cs
+++ b/tests/AgenStart.Platform.Windows.Tests/WinGetProviderTests.cs
@@ -1,0 +1,100 @@
+using AgenStart.PackageManagement;
+using AgenStart.Platform.Windows.WinGet;
+
+namespace AgenStart.Platform.Windows.Tests;
+
+public sealed class WinGetProviderTests
+{
+    [Fact]
+    public async Task ResolveAsync_DoesNotFallbackToAnotherSource()
+    {
+        var locator = new FakeLocator("C:\\Users\\test\\AppData\\Local\\Microsoft\\WindowsApps\\winget.exe");
+        var runner = new RecordingRunner(
+            new WinGetProcessResult(
+                true,
+                HResult(0x8A150045u),
+                string.Empty,
+                string.Empty));
+        var provider = new WinGetProvider(locator, runner);
+        var package = new ProviderPackageReference(
+            PackageProviderIds.WinGet,
+            "Microsoft.PowerToys",
+            "winget");
+
+        var result = await provider.ResolveAsync(package);
+
+        Assert.Equal(PackageResolutionStatus.SourceUnavailable, result.Status);
+        Assert.Single(runner.Calls);
+        Assert.Contains("winget", runner.Calls[0].Arguments);
+        Assert.DoesNotContain("msstore", runner.Calls[0].Arguments);
+    }
+
+    [Fact]
+    public async Task InstallAsync_InvalidReferenceNeverStartsProcess()
+    {
+        var locator = new FakeLocator("C:\\Users\\test\\AppData\\Local\\Microsoft\\WindowsApps\\winget.exe");
+        var runner = new RecordingRunner(new WinGetProcessResult(true, 0, string.Empty, string.Empty));
+        var provider = new WinGetProvider(locator, runner);
+        var request = new PackageInstallRequest(
+            "git",
+            new ProviderPackageReference(
+                PackageProviderIds.WinGet,
+                "Git.Git --override",
+                "winget"));
+
+        var result = await provider.InstallAsync(request);
+
+        Assert.Equal(PackageOperationStatus.Failed, result.Status);
+        Assert.Equal("winget.invalid-install-request", result.DiagnosticCode);
+        Assert.Empty(runner.Calls);
+    }
+
+    [Fact]
+    public async Task InstallAsync_UsesStructuredResultWithoutReturningRawProviderOutput()
+    {
+        var locator = new FakeLocator("C:\\Users\\test\\AppData\\Local\\Microsoft\\WindowsApps\\winget.exe");
+        var runner = new RecordingRunner(
+            new WinGetProcessResult(
+                true,
+                HResult(0x8A150011u),
+                "C:\\Users\\SensitiveUser\\Downloads\\payload.exe",
+                "hash mismatch at sensitive path"));
+        var provider = new WinGetProvider(locator, runner);
+        var request = new PackageInstallRequest(
+            "git",
+            new ProviderPackageReference(PackageProviderIds.WinGet, "Git.Git", "winget"));
+
+        var result = await provider.InstallAsync(request);
+
+        Assert.Equal(PackageOperationStatus.IntegrityFailure, result.Status);
+        Assert.DoesNotContain("SensitiveUser", result.Message ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("payload.exe", result.Message ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int HResult(uint value) => unchecked((int)value);
+
+    private sealed class FakeLocator(string path) : IWinGetExecutableLocator
+    {
+        public WinGetExecutableResolution Resolve() => new(true, path);
+    }
+
+    private sealed class RecordingRunner(WinGetProcessResult response) : IWinGetProcessRunner
+    {
+        public List<Call> Calls { get; } = [];
+
+        public Task<WinGetProcessResult> RunAsync(
+            string executablePath,
+            IReadOnlyList<string> arguments,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            Calls.Add(new Call(executablePath, arguments.ToArray(), timeout));
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed record Call(
+        string ExecutablePath,
+        IReadOnlyList<string> Arguments,
+        TimeSpan Timeout);
+}

--- a/tests/AgenStart.Platform.Windows.Tests/WinGetResultNormalizerTests.cs
+++ b/tests/AgenStart.Platform.Windows.Tests/WinGetResultNormalizerTests.cs
@@ -1,0 +1,92 @@
+using AgenStart.PackageManagement;
+using AgenStart.Platform.Windows.WinGet;
+
+namespace AgenStart.Platform.Windows.Tests;
+
+public sealed class WinGetResultNormalizerTests
+{
+    [Fact]
+    public void Normalize_MapsSuccess()
+    {
+        var result = WinGetResultNormalizer.Normalize(ProcessResult(0));
+
+        Assert.Equal(PackageOperationStatus.Succeeded, result.Status);
+        Assert.Equal("winget.success", result.DiagnosticCode);
+    }
+
+    [Theory]
+    [InlineData(0x8A150061u)]
+    [InlineData(0x8A15010Du)]
+    public void Normalize_MapsAlreadyInstalled(uint hresult)
+    {
+        var result = WinGetResultNormalizer.Normalize(ProcessResult(HResult(hresult)));
+
+        Assert.Equal(PackageOperationStatus.AlreadyInstalled, result.Status);
+    }
+
+    [Theory]
+    [InlineData(0x8A150011u)]
+    [InlineData(0x8A15002Du)]
+    [InlineData(0x8A15003Fu)]
+    [InlineData(0x8A15005Eu)]
+    [InlineData(0x8A150060u)]
+    public void Normalize_MapsIntegrityFailures(uint hresult)
+    {
+        var result = WinGetResultNormalizer.Normalize(ProcessResult(HResult(hresult)));
+
+        Assert.Equal(PackageOperationStatus.IntegrityFailure, result.Status);
+    }
+
+    [Theory]
+    [InlineData(0x8A150041u)]
+    [InlineData(0x8A150046u)]
+    public void Normalize_MapsAgreementRequirements(uint hresult)
+    {
+        var result = WinGetResultNormalizer.Normalize(ProcessResult(HResult(hresult)));
+
+        Assert.Equal(PackageOperationStatus.AgreementRequired, result.Status);
+    }
+
+    [Fact]
+    public void Normalize_CancellationWinsOverNativeExitCode()
+    {
+        var result = WinGetResultNormalizer.Normalize(
+            new WinGetProcessResult(
+                true,
+                HResult(0x8A150003u),
+                string.Empty,
+                string.Empty,
+                Cancelled: true));
+
+        Assert.Equal(PackageOperationStatus.Cancelled, result.Status);
+        Assert.Equal("provider.cancelled", result.DiagnosticCode);
+    }
+
+    [Fact]
+    public void Normalize_TimeoutWinsOverNativeExitCode()
+    {
+        var result = WinGetResultNormalizer.Normalize(
+            new WinGetProcessResult(
+                true,
+                null,
+                string.Empty,
+                string.Empty,
+                TimedOut: true));
+
+        Assert.Equal(PackageOperationStatus.TimedOut, result.Status);
+    }
+
+    [Fact]
+    public void Normalize_UnknownCodeFailsClosed()
+    {
+        var result = WinGetResultNormalizer.Normalize(ProcessResult(123456));
+
+        Assert.Equal(PackageOperationStatus.Failed, result.Status);
+        Assert.Equal("winget.unmapped-error", result.DiagnosticCode);
+    }
+
+    private static WinGetProcessResult ProcessResult(int exitCode) =>
+        new(true, exitCode, string.Empty, string.Empty);
+
+    private static int HResult(uint value) => unchecked((int)value);
+}


### PR DESCRIPTION
## Summary

Introduces AgenStart's first executable C# package-provider foundation for the Windows MVP.

### Package-provider contracts
- adds `AgenStart.PackageManagement` on .NET 10
- defines typed provider references and install requests
- defines provider availability, resolution and operation result states
- exposes `IPackageProvider` without raw shell/argument passthrough

### WinGet adapter
- adds `AgenStart.Platform.Windows`
- resolves WinGet only through trusted per-user App Execution Alias locations
- invokes WinGet directly with `ProcessStartInfo.UseShellExecute = false`
- builds arguments through `ArgumentList`
- uses exact package ID + exact trusted source
- trusts only `winget` and `msstore` for the MVP
- never falls back to another source automatically
- disables hidden CLI interaction
- only adds agreement flags after explicit request consent
- rejects package IDs that can be interpreted as flags/command fragments
- excludes override/custom/force/hash-bypass/reboot bypass flags
- supports cancellation and bounded timeouts with process-tree termination

### Result normalization
Normalizes known WinGet HRESULT families into AgenStart states including:
- already installed
- not found / ambiguous
- no applicable installer
- source unavailable
- agreement required
- elevation required
- policy blocked
- integrity/security failure
- network failure
- reboot required
- user cancellation / cancellation / timeout
- provider unavailable
- unknown failure (fail closed)

### Verification
- xUnit tests for safe argument construction
- result-normalization tests
- provider tests proving no implicit source fallback and no raw provider output in UI messages
- Windows GitHub Actions test gate on .NET 10

### Documentation
- adds `docs/architecture/package-provider.md`
- records retry/fallback/elevation/consent boundaries
- marks ADR-0002 `Accepted` now that the security decision is merged and implemented

Closes #4