### PR TITLE
chore: enable AppFactory Project bootstrap

### DIFF
--- a/.github/project-config.json
+++ b/.github/project-config.json
@@ -1,7 +1,20 @@
 {
   "project": {
     "owner": "EagleFox31",
-    "title": "AgenStart Product Development"
+    "title": "AgenStart Product Development",
+    "bootstrap": true,
+    "template": "appfactory-product"
+  },
+  "bootstrap": {
+    "phases": [
+      "Foundation",
+      "Machine Intelligence",
+      "Recommendations",
+      "Installation",
+      "Desktop MVP",
+      "Reproducible Setup",
+      "Release"
+    ]
   },
   "metadataCommentKey": "agenstart-project",
   "fields": {

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,8 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to resync (e.g. 15, #15, or issue_number = 15)"
-        required: true
+        description: "Optional issue number to resync; leave blank to bootstrap/reconcile the Project"
+        required: false
+        default: ""
         type: string
 
 permissions:
@@ -18,7 +19,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: agenstart-project-automation-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || inputs.issue_number }}
+  group: agenstart-project-automation-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || inputs.issue_number || 'bootstrap' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Enables the new AppFactory Project Automation v1.1 bootstrap mode for AgenStart without replacing the existing Project.

- enables `project.bootstrap`
- uses the built-in `appfactory-product` template
- preserves the legacy `agenstart-project` metadata marker
- declares AgenStart's existing product phases explicitly
- keeps all current issue overrides and lifecycle transitions
- makes `workflow_dispatch.issue_number` optional so a blank manual run performs full Project bootstrap/reconciliation

The bootstrap is non-destructive: the existing `AgenStart Product Development` Project is reused and missing fields/options are reconciled rather than recreated.