### PR TITLE
feat: detect installed applications and normalize software state

### DIFF
--- a/.github/workflows/package-management-tests.yml
+++ b/.github/workflows/package-management-tests.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     paths:
       - "src/AgenStart.PackageManagement/**"
+      - "src/AgenStart.SoftwareInventory/**"
       - "src/AgenStart.Platform.Windows/**"
       - "tests/AgenStart.Platform.Windows.Tests/**"
       - "docs/architecture/package-provider.md"
+      - "docs/architecture/installed-software-inventory.md"
       - ".github/workflows/package-management-tests.yml"
   workflow_dispatch:
 

--- a/docs/architecture/installed-software-inventory.md
+++ b/docs/architecture/installed-software-inventory.md
@@ -1,0 +1,155 @@
+# Installed software inventory
+
+Status: Implemented for Windows MVP
+
+Related issue: #5
+
+## Purpose
+
+AgenStart must know which curated applications are already installed before it recommends or installs software. Detection is local, read-only, privacy-minimal, and conservative: uncertainty becomes `Unknown`, never a guessed `Installed` state.
+
+## Windows inventory sources
+
+The Windows MVP combines two complementary sources.
+
+### WinGet structured export
+
+AgenStart runs WinGet directly with a typed argument list and exports installed packages separately for the trusted `winget` and `msstore` sources.
+
+The command shape is:
+
+```text
+winget export --output <AgenStart temp json> --source <trusted source> --include-versions --disable-interactivity
+```
+
+The JSON export is parsed structurally. AgenStart records:
+
+- provider ID (`winget`);
+- package ID;
+- trusted package source;
+- installed version when present;
+- installation scope when WinGet supplies it.
+
+AgenStart never parses the human-readable `winget list` table.
+
+Only the trusted MVP sources `winget` and `msstore` are queried. User-added/custom WinGet sources are not automatically trusted.
+
+### Windows uninstall registry
+
+AgenStart reads the standard uninstall inventory in read-only mode from:
+
+```text
+HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
+HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
+```
+
+Both 32-bit and 64-bit registry views are inspected. The collector reads only software metadata required for detection:
+
+- `DisplayName`;
+- `Publisher`;
+- `DisplayVersion`;
+- `SystemComponent` to omit hidden system components.
+
+No personal user files, browser data, document folders, file names, serial numbers, MAC addresses, or unrelated registry data are inspected.
+
+## Snapshot model
+
+Collectors return normalized `InstalledSoftwareRecord` values plus one `InventorySourceStatus` per source. The composite inventory provider merges and deduplicates records into a timestamped `InstalledSoftwareSnapshot`.
+
+Source states are explicit:
+
+- `Complete`
+- `Partial`
+- `Unavailable`
+- `Failed`
+- `TimedOut`
+
+A partial source does not invalidate records successfully collected from other sources.
+
+## Catalogue matching
+
+Runtime catalogue entries are represented to the resolver as `SoftwareDetectionTarget` values containing:
+
+- canonical AgenStart application ID;
+- display name;
+- expected publisher;
+- exact provider package references;
+- optional exact registry display-name aliases.
+
+Matching intentionally avoids fuzzy execution-time guesses.
+
+### Provider identity
+
+The strongest match is the tuple:
+
+```text
+provider ID + package source + package ID
+```
+
+For example:
+
+```text
+winget + winget + Microsoft.VisualStudioCode
+```
+
+A provider identity mapped to more than one canonical application is ambiguous and does not silently confirm installation.
+
+### Registry identity
+
+Registry evidence requires an exact normalized display-name match and a compatible expected publisher. Explicit registry aliases may be supplied for curated products whose Windows display name differs from the catalogue name.
+
+If one registry record matches more than one catalogue application, every affected application remains `Unknown` unless independent unambiguous evidence confirms it.
+
+## Presence states
+
+### Installed
+
+An application is `Installed` when at least one unambiguous exact provider or registry identity is observed.
+
+When exactly one installed version is observed, AgenStart reports it. If multiple different versions are present, the application remains `Installed` but the normalized version is left empty and a diagnostic is attached.
+
+### Missing
+
+An application is `Missing` only when the inventory source required to prove absence completed successfully and no matching identity was observed.
+
+### Unknown
+
+An application is `Unknown` when AgenStart cannot safely prove either presence or absence, including:
+
+- ambiguous identity;
+- unavailable provider;
+- partial source read;
+- failed or timed-out source;
+- insufficient trustworthy evidence.
+
+This fail-conservative behavior prevents duplicate install proposals caused by guessed absence.
+
+## Unknown software
+
+Software that does not map to the curated catalogue is retained in the raw snapshot but does not break detection. `SoftwareDetectionResult.UnmappedRecordCount` makes that condition observable without treating arbitrary installed software as an error.
+
+## Failure and cleanup behavior
+
+WinGet exports are written only to AgenStart-generated temporary paths and removed on a best-effort basis after parsing. The collector never targets user-owned files for deletion.
+
+Expected registry access failures degrade the registry source to `Partial` rather than failing the whole inventory.
+
+Cancellation is propagated to the caller.
+
+## Testing
+
+Fixture-based tests cover representative WinGet exports and edge cases including:
+
+- exact package identity;
+- version and scope capture;
+- source separation;
+- unknown packages;
+- exact registry matching;
+- ambiguous registry matches;
+- `Missing` versus `Unknown` based on source completeness;
+- multiple installed versions;
+- collector aggregation and deduplication.
+
+## Boundary with later features
+
+Issue #5 detects and normalizes installed state. It does not decide what should be recommended. The recommendation engine consumes these normalized states in issue #6 so already-installed applications can be excluded or explained correctly.

--- a/src/AgenStart.Platform.Windows/SoftwareInventory/RegistryInstalledSoftwareCollector.cs
+++ b/src/AgenStart.Platform.Windows/SoftwareInventory/RegistryInstalledSoftwareCollector.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using System.Security;
 using AgenStart.SoftwareInventory;
 using Microsoft.Win32;
@@ -22,6 +23,13 @@ public sealed class RegistryInstalledSoftwareCollector : IInstalledSoftwareColle
                     "Windows uninstall registry inventory is unavailable on this platform.")]));
         }
 
+        return CollectWindowsAsync(cancellationToken);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static Task<InstalledSoftwareCollectionResult> CollectWindowsAsync(
+        CancellationToken cancellationToken)
+    {
         var records = new HashSet<InstalledSoftwareRecord>();
         var hadErrors = false;
 
@@ -57,6 +65,7 @@ public sealed class RegistryInstalledSoftwareCollector : IInstalledSoftwareColle
             [status]));
     }
 
+    [SupportedOSPlatform("windows")]
     private static IEnumerable<RegistryProbe> RegistryProbes()
     {
         yield return new RegistryProbe(
@@ -80,6 +89,7 @@ public sealed class RegistryInstalledSoftwareCollector : IInstalledSoftwareColle
             InstalledSoftwareScope.User);
     }
 
+    [SupportedOSPlatform("windows")]
     private static void ReadProbe(
         RegistryProbe probe,
         ISet<InstalledSoftwareRecord> records,
@@ -137,6 +147,7 @@ public sealed class RegistryInstalledSoftwareCollector : IInstalledSoftwareColle
         }
     }
 
+    [SupportedOSPlatform("windows")]
     private static bool IsHiddenSystemComponent(RegistryKey key)
     {
         var value = key.GetValue("SystemComponent", null, RegistryValueOptions.DoNotExpandEnvironmentNames);
@@ -149,6 +160,7 @@ public sealed class RegistryInstalledSoftwareCollector : IInstalledSoftwareColle
         };
     }
 
+    [SupportedOSPlatform("windows")]
     private static string? ReadString(RegistryKey key, string valueName)
     {
         var value = key.GetValue(valueName, null, RegistryValueOptions.DoNotExpandEnvironmentNames);

--- a/src/AgenStart.Platform.Windows/SoftwareInventory/RegistryInstalledSoftwareCollector.cs
+++ b/src/AgenStart.Platform.Windows/SoftwareInventory/RegistryInstalledSoftwareCollector.cs
@@ -1,0 +1,167 @@
+using System.Security;
+using AgenStart.SoftwareInventory;
+using Microsoft.Win32;
+
+namespace AgenStart.Platform.Windows.SoftwareInventory;
+
+public sealed class RegistryInstalledSoftwareCollector : IInstalledSoftwareCollector
+{
+    private const string UninstallPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
+
+    public Task<InstalledSoftwareCollectionResult> CollectAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return Task.FromResult(new InstalledSoftwareCollectionResult(
+                [],
+                [new InventorySourceStatus(
+                    SoftwareInventorySourceIds.WindowsRegistry,
+                    InventorySourceState.Unavailable,
+                    "registry.unsupported-platform",
+                    "Windows uninstall registry inventory is unavailable on this platform.")]));
+        }
+
+        var records = new HashSet<InstalledSoftwareRecord>();
+        var hadErrors = false;
+
+        foreach (var probe in RegistryProbes())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                ReadProbe(probe, records, cancellationToken, ref hadErrors);
+            }
+            catch (Exception exception) when (IsExpectedRegistryFailure(exception))
+            {
+                hadErrors = true;
+            }
+        }
+
+        var status = hadErrors
+            ? new InventorySourceStatus(
+                SoftwareInventorySourceIds.WindowsRegistry,
+                InventorySourceState.Partial,
+                "registry.partial-read",
+                "Some installed-software registry entries could not be read as the current user.")
+            : new InventorySourceStatus(
+                SoftwareInventorySourceIds.WindowsRegistry,
+                InventorySourceState.Complete);
+
+        return Task.FromResult(new InstalledSoftwareCollectionResult(
+            records
+                .OrderBy(record => record.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(record => record.Version, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            [status]));
+    }
+
+    private static IEnumerable<RegistryProbe> RegistryProbes()
+    {
+        yield return new RegistryProbe(
+            RegistryHive.LocalMachine,
+            RegistryView.Registry64,
+            InstalledSoftwareScope.Machine);
+
+        yield return new RegistryProbe(
+            RegistryHive.LocalMachine,
+            RegistryView.Registry32,
+            InstalledSoftwareScope.Machine);
+
+        yield return new RegistryProbe(
+            RegistryHive.CurrentUser,
+            RegistryView.Registry64,
+            InstalledSoftwareScope.User);
+
+        yield return new RegistryProbe(
+            RegistryHive.CurrentUser,
+            RegistryView.Registry32,
+            InstalledSoftwareScope.User);
+    }
+
+    private static void ReadProbe(
+        RegistryProbe probe,
+        ISet<InstalledSoftwareRecord> records,
+        CancellationToken cancellationToken,
+        ref bool hadErrors)
+    {
+        using var baseKey = RegistryKey.OpenBaseKey(probe.Hive, probe.View);
+        using var uninstallKey = baseKey.OpenSubKey(UninstallPath, writable: false);
+        if (uninstallKey is null)
+        {
+            return;
+        }
+
+        string[] subKeyNames;
+        try
+        {
+            subKeyNames = uninstallKey.GetSubKeyNames();
+        }
+        catch (Exception exception) when (IsExpectedRegistryFailure(exception))
+        {
+            hadErrors = true;
+            return;
+        }
+
+        foreach (var subKeyName in subKeyNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                using var applicationKey = uninstallKey.OpenSubKey(subKeyName, writable: false);
+                if (applicationKey is null || IsHiddenSystemComponent(applicationKey))
+                {
+                    continue;
+                }
+
+                var displayName = ReadString(applicationKey, "DisplayName");
+                if (string.IsNullOrWhiteSpace(displayName))
+                {
+                    continue;
+                }
+
+                records.Add(new InstalledSoftwareRecord(
+                    InstalledSoftwareSourceKind.Registry,
+                    SoftwareInventorySourceIds.WindowsRegistry,
+                    displayName.Trim(),
+                    ReadString(applicationKey, "Publisher"),
+                    ReadString(applicationKey, "DisplayVersion"),
+                    probe.Scope));
+            }
+            catch (Exception exception) when (IsExpectedRegistryFailure(exception))
+            {
+                hadErrors = true;
+            }
+        }
+    }
+
+    private static bool IsHiddenSystemComponent(RegistryKey key)
+    {
+        var value = key.GetValue("SystemComponent", null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+        return value switch
+        {
+            int integer => integer == 1,
+            long longInteger => longInteger == 1,
+            string text => string.Equals(text.Trim(), "1", StringComparison.Ordinal),
+            _ => false
+        };
+    }
+
+    private static string? ReadString(RegistryKey key, string valueName)
+    {
+        var value = key.GetValue(valueName, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+        return value is string text && !string.IsNullOrWhiteSpace(text)
+            ? text.Trim()
+            : null;
+    }
+
+    private static bool IsExpectedRegistryFailure(Exception exception) =>
+        exception is SecurityException or UnauthorizedAccessException or IOException;
+
+    private sealed record RegistryProbe(
+        RegistryHive Hive,
+        RegistryView View,
+        InstalledSoftwareScope Scope);
+}

--- a/src/AgenStart.Platform.Windows/SoftwareInventory/WinGetInstalledSoftwareCollector.cs
+++ b/src/AgenStart.Platform.Windows/SoftwareInventory/WinGetInstalledSoftwareCollector.cs
@@ -32,7 +32,7 @@ public sealed class WinGetInstalledSoftwareCollector : IInstalledSoftwareCollect
         var executable = _locator.Resolve();
         if (!executable.Found || string.IsNullOrWhiteSpace(executable.Path))
         {
-            var statuses = TrustedSources
+            var unavailableStatuses = TrustedSources
                 .Select(source => new InventorySourceStatus(
                     SoftwareInventorySourceIds.ForPackageProvider(PackageProviderIds.WinGet, source),
                     InventorySourceState.Unavailable,
@@ -40,7 +40,7 @@ public sealed class WinGetInstalledSoftwareCollector : IInstalledSoftwareCollect
                     executable.Message ?? "WinGet is unavailable for installed-software inventory."))
                 .ToArray();
 
-            return new InstalledSoftwareCollectionResult([], statuses);
+            return new InstalledSoftwareCollectionResult([], unavailableStatuses);
         }
 
         var records = new HashSet<InstalledSoftwareRecord>();

--- a/src/AgenStart.Platform.Windows/SoftwareInventory/WinGetInstalledSoftwareCollector.cs
+++ b/src/AgenStart.Platform.Windows/SoftwareInventory/WinGetInstalledSoftwareCollector.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using AgenStart.PackageManagement;
+using AgenStart.Platform.Windows.WinGet;
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Platform.Windows.SoftwareInventory;
+
+public sealed class WinGetInstalledSoftwareCollector : IInstalledSoftwareCollector
+{
+    private static readonly string[] TrustedSources = ["winget", "msstore"];
+    private static readonly TimeSpan ExportTimeout = TimeSpan.FromSeconds(90);
+
+    private readonly IWinGetExecutableLocator _locator;
+    private readonly IWinGetProcessRunner _runner;
+
+    public WinGetInstalledSoftwareCollector()
+        : this(new WinGetExecutableLocator(), new WinGetProcessRunner())
+    {
+    }
+
+    public WinGetInstalledSoftwareCollector(
+        IWinGetExecutableLocator locator,
+        IWinGetProcessRunner runner)
+    {
+        _locator = locator ?? throw new ArgumentNullException(nameof(locator));
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+    }
+
+    public async Task<InstalledSoftwareCollectionResult> CollectAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var executable = _locator.Resolve();
+        if (!executable.Found || string.IsNullOrWhiteSpace(executable.Path))
+        {
+            var statuses = TrustedSources
+                .Select(source => new InventorySourceStatus(
+                    SoftwareInventorySourceIds.ForPackageProvider(PackageProviderIds.WinGet, source),
+                    InventorySourceState.Unavailable,
+                    executable.DiagnosticCode ?? "winget.inventory-unavailable",
+                    executable.Message ?? "WinGet is unavailable for installed-software inventory."))
+                .ToArray();
+
+            return new InstalledSoftwareCollectionResult([], statuses);
+        }
+
+        var records = new HashSet<InstalledSoftwareRecord>();
+        var statuses = new List<InventorySourceStatus>(TrustedSources.Length);
+
+        foreach (var source in TrustedSources)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var result = await ExportSourceAsync(
+                executable.Path,
+                source,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var record in result.Records)
+            {
+                records.Add(record);
+            }
+
+            statuses.Add(result.Status);
+        }
+
+        return new InstalledSoftwareCollectionResult(
+            records
+                .OrderBy(record => record.PackageSource, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(record => record.PackageId, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            statuses);
+    }
+
+    private async Task<SourceExportResult> ExportSourceAsync(
+        string executablePath,
+        string source,
+        CancellationToken cancellationToken)
+    {
+        var sourceId = SoftwareInventorySourceIds.ForPackageProvider(PackageProviderIds.WinGet, source);
+        var directory = Path.Combine(Path.GetTempPath(), "AgenStart", "software-inventory");
+        Directory.CreateDirectory(directory);
+
+        var outputPath = Path.Combine(directory, $"{source}-{Guid.NewGuid():N}.json");
+        var command = WinGetCommandBuilder.BuildExportInstalled(source, outputPath);
+
+        try
+        {
+            var processResult = await _runner.RunAsync(
+                executablePath,
+                command.Arguments,
+                ExportTimeout,
+                cancellationToken).ConfigureAwait(false);
+
+            var parsedRecords = TryReadExport(outputPath, source, out var parseFailed);
+
+            if (parsedRecords.Count > 0 || File.Exists(outputPath))
+            {
+                var state = processResult.ExitCode == 0 && !parseFailed
+                    ? InventorySourceState.Complete
+                    : InventorySourceState.Partial;
+
+                return new SourceExportResult(
+                    parsedRecords,
+                    new InventorySourceStatus(
+                        sourceId,
+                        state,
+                        state == InventorySourceState.Partial ? "winget.export-partial" : null,
+                        state == InventorySourceState.Partial
+                            ? "WinGet produced only a partial or non-clean installed-package export for this trusted source."
+                            : null));
+            }
+
+            var normalized = WinGetResultNormalizer.Normalize(processResult);
+            var stateWithoutFile = normalized.Status switch
+            {
+                PackageOperationStatus.TimedOut => InventorySourceState.TimedOut,
+                PackageOperationStatus.ProviderUnavailable => InventorySourceState.Unavailable,
+                PackageOperationStatus.Cancelled or PackageOperationStatus.CancelledByUser => InventorySourceState.Partial,
+                _ => InventorySourceState.Failed
+            };
+
+            return new SourceExportResult(
+                [],
+                new InventorySourceStatus(
+                    sourceId,
+                    stateWithoutFile,
+                    $"winget.inventory.{normalized.DiagnosticCode}",
+                    "WinGet could not produce an installed-package export for this trusted source."));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return new SourceExportResult(
+                [],
+                new InventorySourceStatus(
+                    sourceId,
+                    InventorySourceState.Failed,
+                    "winget.export-read-failed",
+                    "AgenStart could not safely read the WinGet installed-package export."));
+        }
+        finally
+        {
+            TryDelete(outputPath);
+        }
+    }
+
+    private static IReadOnlyList<InstalledSoftwareRecord> TryReadExport(
+        string outputPath,
+        string source,
+        out bool parseFailed)
+    {
+        parseFailed = false;
+
+        if (!File.Exists(outputPath))
+        {
+            return [];
+        }
+
+        try
+        {
+            var json = File.ReadAllText(outputPath);
+            return WinGetInstalledSoftwareExportParser.Parse(json, source);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            parseFailed = true;
+            return [];
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // Best effort cleanup. No user file is ever targeted: the path is generated by AgenStart.
+        }
+    }
+
+    private sealed record SourceExportResult(
+        IReadOnlyList<InstalledSoftwareRecord> Records,
+        InventorySourceStatus Status);
+}

--- a/src/AgenStart.Platform.Windows/SoftwareInventory/WinGetInstalledSoftwareExportParser.cs
+++ b/src/AgenStart.Platform.Windows/SoftwareInventory/WinGetInstalledSoftwareExportParser.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using AgenStart.PackageManagement;
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Platform.Windows.SoftwareInventory;
+
+public static class WinGetInstalledSoftwareExportParser
+{
+    public static IReadOnlyList<InstalledSoftwareRecord> Parse(
+        string json,
+        string expectedSource)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedSource);
+
+        using var document = JsonDocument.Parse(json, new JsonDocumentOptions
+        {
+            AllowTrailingCommas = false,
+            CommentHandling = JsonCommentHandling.Disallow,
+            MaxDepth = 32
+        });
+
+        if (!document.RootElement.TryGetProperty("Sources", out var sources) ||
+            sources.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException("WinGet export does not contain a Sources array.");
+        }
+
+        var records = new HashSet<InstalledSoftwareRecord>();
+        var sourceId = SoftwareInventorySourceIds.ForPackageProvider(
+            PackageProviderIds.WinGet,
+            expectedSource);
+
+        foreach (var source in sources.EnumerateArray())
+        {
+            if (!TryGetSourceName(source, out var sourceName) ||
+                !string.Equals(sourceName, expectedSource, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!source.TryGetProperty("Packages", out var packages) ||
+                packages.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var package in packages.EnumerateArray())
+            {
+                if (!package.TryGetProperty("PackageIdentifier", out var identifierElement) ||
+                    identifierElement.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                var packageId = identifierElement.GetString()?.Trim();
+                if (string.IsNullOrWhiteSpace(packageId))
+                {
+                    continue;
+                }
+
+                var version = ReadOptionalString(package, "Version");
+                var scope = ReadScope(package);
+
+                records.Add(new InstalledSoftwareRecord(
+                    InstalledSoftwareSourceKind.PackageProvider,
+                    sourceId,
+                    packageId,
+                    Version: version,
+                    Scope: scope,
+                    ProviderId: PackageProviderIds.WinGet,
+                    PackageId: packageId,
+                    PackageSource: expectedSource));
+            }
+        }
+
+        return records
+            .OrderBy(record => record.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(record => record.Version, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static bool TryGetSourceName(JsonElement source, out string? sourceName)
+    {
+        sourceName = null;
+
+        if (!source.TryGetProperty("SourceDetails", out var details) ||
+            details.ValueKind != JsonValueKind.Object ||
+            !details.TryGetProperty("Name", out var nameElement) ||
+            nameElement.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        sourceName = nameElement.GetString()?.Trim();
+        return !string.IsNullOrWhiteSpace(sourceName);
+    }
+
+    private static string? ReadOptionalString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var value) || value.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var text = value.GetString()?.Trim();
+        return string.IsNullOrWhiteSpace(text) ? null : text;
+    }
+
+    private static InstalledSoftwareScope ReadScope(JsonElement package) =>
+        ReadOptionalString(package, "Scope")?.ToLowerInvariant() switch
+        {
+            "user" => InstalledSoftwareScope.User,
+            "machine" => InstalledSoftwareScope.Machine,
+            _ => InstalledSoftwareScope.Unknown
+        };
+}

--- a/src/AgenStart.Platform.Windows/SoftwareInventory/WindowsInstalledSoftwareInventoryProvider.cs
+++ b/src/AgenStart.Platform.Windows/SoftwareInventory/WindowsInstalledSoftwareInventoryProvider.cs
@@ -1,0 +1,30 @@
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Platform.Windows.SoftwareInventory;
+
+public sealed class WindowsInstalledSoftwareInventoryProvider : IInstalledSoftwareInventoryProvider
+{
+    private readonly CompositeInstalledSoftwareInventoryProvider _inner;
+
+    public WindowsInstalledSoftwareInventoryProvider()
+        : this(
+        [
+            new RegistryInstalledSoftwareCollector(),
+            new WinGetInstalledSoftwareCollector()
+        ])
+    {
+    }
+
+    public WindowsInstalledSoftwareInventoryProvider(
+        IEnumerable<IInstalledSoftwareCollector> collectors,
+        TimeProvider? timeProvider = null)
+    {
+        _inner = new CompositeInstalledSoftwareInventoryProvider(
+            collectors,
+            timeProvider);
+    }
+
+    public Task<InstalledSoftwareSnapshot> CaptureAsync(
+        CancellationToken cancellationToken = default) =>
+        _inner.CaptureAsync(cancellationToken);
+}

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetCommandBuilder.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetCommandBuilder.cs
@@ -30,6 +30,28 @@ public static partial class WinGetCommandBuilder
         ]);
     }
 
+    public static WinGetCommand BuildExportInstalled(string source, string outputPath)
+    {
+        ValidateSource(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+
+        if (!Path.IsPathFullyQualified(outputPath))
+        {
+            throw new ArgumentException(
+                "WinGet export output must be an AgenStart-owned absolute path.",
+                nameof(outputPath));
+        }
+
+        return new WinGetCommand(
+        [
+            "export",
+            "--output", outputPath,
+            "--source", source,
+            "--include-versions",
+            "--disable-interactivity"
+        ]);
+    }
+
     public static WinGetCommand BuildInstall(PackageInstallRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -101,11 +123,16 @@ public static partial class WinGetCommandBuilder
                 nameof(package));
         }
 
-        if (!AllowedSources.Contains(package.Source))
+        ValidateSource(package.Source);
+    }
+
+    private static void ValidateSource(string source)
+    {
+        if (string.IsNullOrWhiteSpace(source) || !AllowedSources.Contains(source))
         {
             throw new ArgumentException(
-                $"WinGet source '{package.Source}' is not trusted by the MVP provider policy.",
-                nameof(package));
+                $"WinGet source '{source}' is not trusted by the MVP provider policy.",
+                nameof(source));
         }
     }
 

--- a/src/AgenStart.SoftwareInventory/AgenStart.SoftwareInventory.csproj
+++ b/src/AgenStart.SoftwareInventory/AgenStart.SoftwareInventory.csproj
@@ -9,6 +9,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AgenStart.PackageManagement\AgenStart.PackageManagement.csproj" />
-    <ProjectReference Include="..\AgenStart.SoftwareInventory\AgenStart.SoftwareInventory.csproj" />
   </ItemGroup>
 </Project>

--- a/src/AgenStart.SoftwareInventory/CompositeInstalledSoftwareInventoryProvider.cs
+++ b/src/AgenStart.SoftwareInventory/CompositeInstalledSoftwareInventoryProvider.cs
@@ -1,0 +1,77 @@
+namespace AgenStart.SoftwareInventory;
+
+public sealed class CompositeInstalledSoftwareInventoryProvider : IInstalledSoftwareInventoryProvider
+{
+    private readonly IReadOnlyList<IInstalledSoftwareCollector> _collectors;
+    private readonly TimeProvider _timeProvider;
+
+    public CompositeInstalledSoftwareInventoryProvider(
+        IEnumerable<IInstalledSoftwareCollector> collectors,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(collectors);
+
+        _collectors = collectors.ToArray();
+        if (_collectors.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one installed-software collector is required.",
+                nameof(collectors));
+        }
+
+        if (_collectors.Any(static collector => collector is null))
+        {
+            throw new ArgumentException(
+                "Installed-software collectors cannot contain null values.",
+                nameof(collectors));
+        }
+
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<InstalledSoftwareSnapshot> CaptureAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var records = new HashSet<InstalledSoftwareRecord>();
+        var statuses = new Dictionary<string, InventorySourceStatus>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var collector in _collectors)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var result = await collector
+                .CollectAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            ArgumentNullException.ThrowIfNull(result);
+
+            foreach (var record in result.Records)
+            {
+                records.Add(record);
+            }
+
+            foreach (var status in result.Sources)
+            {
+                if (string.IsNullOrWhiteSpace(status.SourceId))
+                {
+                    throw new InvalidOperationException(
+                        "Installed-software collectors must return a non-empty source ID.");
+                }
+
+                statuses[status.SourceId.Trim()] = status;
+            }
+        }
+
+        return new InstalledSoftwareSnapshot(
+            records
+                .OrderBy(record => record.SourceKind)
+                .ThenBy(record => record.SourceId, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(record => record.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(record => record.Version, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            statuses.Values
+                .OrderBy(status => status.SourceId, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            _timeProvider.GetUtcNow());
+    }
+}

--- a/src/AgenStart.SoftwareInventory/SoftwareInventoryContracts.cs
+++ b/src/AgenStart.SoftwareInventory/SoftwareInventoryContracts.cs
@@ -1,0 +1,95 @@
+using AgenStart.PackageManagement;
+
+namespace AgenStart.SoftwareInventory;
+
+public enum InstalledSoftwareSourceKind
+{
+    Registry = 0,
+    PackageProvider = 1
+}
+
+public enum InstalledSoftwareScope
+{
+    Unknown = 0,
+    User = 1,
+    Machine = 2
+}
+
+public enum InventorySourceState
+{
+    Complete = 0,
+    Partial,
+    Unavailable,
+    Failed,
+    TimedOut
+}
+
+public sealed record InventorySourceStatus(
+    string SourceId,
+    InventorySourceState State,
+    string? DiagnosticCode = null,
+    string? Message = null)
+{
+    public bool IsComplete => State == InventorySourceState.Complete;
+}
+
+public sealed record InstalledSoftwareRecord(
+    InstalledSoftwareSourceKind SourceKind,
+    string SourceId,
+    string DisplayName,
+    string? Publisher = null,
+    string? Version = null,
+    InstalledSoftwareScope Scope = InstalledSoftwareScope.Unknown,
+    string? ProviderId = null,
+    string? PackageId = null,
+    string? PackageSource = null);
+
+public sealed record InstalledSoftwareCollectionResult(
+    IReadOnlyList<InstalledSoftwareRecord> Records,
+    IReadOnlyList<InventorySourceStatus> Sources);
+
+public interface IInstalledSoftwareCollector
+{
+    Task<InstalledSoftwareCollectionResult> CollectAsync(
+        CancellationToken cancellationToken = default);
+}
+
+public interface IInstalledSoftwareInventoryProvider
+{
+    Task<InstalledSoftwareSnapshot> CaptureAsync(
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record InstalledSoftwareSnapshot(
+    IReadOnlyList<InstalledSoftwareRecord> Records,
+    IReadOnlyList<InventorySourceStatus> Sources,
+    DateTimeOffset CapturedAtUtc);
+
+public sealed record SoftwareDetectionTarget(
+    string ApplicationId,
+    string DisplayName,
+    string Publisher,
+    IReadOnlyList<ProviderPackageReference> ProviderPackages,
+    IReadOnlyList<string> RegistryDisplayNames);
+
+public enum SoftwarePresenceState
+{
+    Installed = 0,
+    Missing,
+    Unknown
+}
+
+public sealed record SoftwareStateDiagnostic(
+    string Code,
+    string Message);
+
+public sealed record DetectedApplicationState(
+    string ApplicationId,
+    SoftwarePresenceState State,
+    string? InstalledVersion,
+    IReadOnlyList<InstalledSoftwareRecord> Evidence,
+    IReadOnlyList<SoftwareStateDiagnostic> Diagnostics);
+
+public sealed record SoftwareDetectionResult(
+    IReadOnlyList<DetectedApplicationState> Applications,
+    int UnmappedRecordCount);

--- a/src/AgenStart.SoftwareInventory/SoftwareInventorySourceIds.cs
+++ b/src/AgenStart.SoftwareInventory/SoftwareInventorySourceIds.cs
@@ -1,0 +1,14 @@
+namespace AgenStart.SoftwareInventory;
+
+public static class SoftwareInventorySourceIds
+{
+    public const string WindowsRegistry = "registry:windows";
+
+    public static string ForPackageProvider(string providerId, string source) =>
+        $"provider:{Normalize(providerId)}:{Normalize(source)}";
+
+    private static string Normalize(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? "unknown"
+            : value.Trim().ToLowerInvariant();
+}

--- a/src/AgenStart.SoftwareInventory/SoftwareStateResolver.cs
+++ b/src/AgenStart.SoftwareInventory/SoftwareStateResolver.cs
@@ -1,0 +1,361 @@
+using System.Text.RegularExpressions;
+
+namespace AgenStart.SoftwareInventory;
+
+public sealed partial class SoftwareStateResolver
+{
+    public SoftwareDetectionResult Resolve(
+        IReadOnlyList<SoftwareDetectionTarget> targets,
+        InstalledSoftwareSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(targets);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        ValidateTargets(targets);
+
+        var sourceStatus = snapshot.Sources
+            .GroupBy(status => Normalize(status.SourceId), StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Last(),
+                StringComparer.Ordinal);
+
+        var providerOwners = BuildProviderOwnerIndex(targets);
+        var registryMatches = BuildRegistryMatches(targets, snapshot.Records);
+        var providerMatches = BuildProviderMatches(targets, snapshot.Records, providerOwners);
+        var usedEvidence = new HashSet<InstalledSoftwareRecord>();
+        var applicationStates = new List<DetectedApplicationState>(targets.Count);
+
+        foreach (var target in targets)
+        {
+            var diagnostics = new List<SoftwareStateDiagnostic>();
+            var evidence = new List<InstalledSoftwareRecord>();
+
+            if (providerMatches.AmbiguousTargets.Contains(target.ApplicationId))
+            {
+                diagnostics.Add(new SoftwareStateDiagnostic(
+                    "inventory.ambiguous-provider-identity",
+                    "A provider package identity maps to more than one catalogue application."));
+            }
+            else if (providerMatches.ByApplication.TryGetValue(target.ApplicationId, out var providerEvidence))
+            {
+                evidence.AddRange(providerEvidence);
+            }
+
+            if (registryMatches.AmbiguousTargets.Contains(target.ApplicationId))
+            {
+                diagnostics.Add(new SoftwareStateDiagnostic(
+                    "inventory.ambiguous-registry-match",
+                    "A registry entry matches more than one catalogue application and was not treated as confirmed."));
+            }
+            else if (registryMatches.ByApplication.TryGetValue(target.ApplicationId, out var registryEvidence))
+            {
+                evidence.AddRange(registryEvidence);
+            }
+
+            if (evidence.Count > 0)
+            {
+                foreach (var record in evidence)
+                {
+                    usedEvidence.Add(record);
+                }
+
+                var version = ResolveVersion(evidence, diagnostics);
+                applicationStates.Add(new DetectedApplicationState(
+                    target.ApplicationId,
+                    SoftwarePresenceState.Installed,
+                    version,
+                    evidence,
+                    diagnostics));
+                continue;
+            }
+
+            if (diagnostics.Count > 0)
+            {
+                applicationStates.Add(new DetectedApplicationState(
+                    target.ApplicationId,
+                    SoftwarePresenceState.Unknown,
+                    null,
+                    [],
+                    diagnostics));
+                continue;
+            }
+
+            var presence = CanProveMissing(target, sourceStatus)
+                ? SoftwarePresenceState.Missing
+                : SoftwarePresenceState.Unknown;
+
+            if (presence == SoftwarePresenceState.Unknown)
+            {
+                diagnostics.Add(new SoftwareStateDiagnostic(
+                    "inventory.insufficient-evidence",
+                    "The required inventory source did not complete, so absence cannot be confirmed."));
+            }
+
+            applicationStates.Add(new DetectedApplicationState(
+                target.ApplicationId,
+                presence,
+                null,
+                [],
+                diagnostics));
+        }
+
+        return new SoftwareDetectionResult(
+            applicationStates,
+            snapshot.Records.Count(record => !usedEvidence.Contains(record)));
+    }
+
+    private static bool CanProveMissing(
+        SoftwareDetectionTarget target,
+        IReadOnlyDictionary<string, InventorySourceStatus> sourceStatus)
+    {
+        if (target.ProviderPackages.Count == 0)
+        {
+            return IsComplete(sourceStatus, SoftwareInventorySourceIds.WindowsRegistry);
+        }
+
+        var requiredProviderSources = target.ProviderPackages
+            .Select(package => SoftwareInventorySourceIds.ForPackageProvider(package.ProviderId, package.Source))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return requiredProviderSources.Length > 0 &&
+               requiredProviderSources.All(sourceId => IsComplete(sourceStatus, sourceId));
+    }
+
+    private static bool IsComplete(
+        IReadOnlyDictionary<string, InventorySourceStatus> sourceStatus,
+        string sourceId) =>
+        sourceStatus.TryGetValue(Normalize(sourceId), out var status) && status.IsComplete;
+
+    private static string? ResolveVersion(
+        IReadOnlyList<InstalledSoftwareRecord> evidence,
+        ICollection<SoftwareStateDiagnostic> diagnostics)
+    {
+        var versions = evidence
+            .Select(record => record.Version?.Trim())
+            .Where(version => !string.IsNullOrWhiteSpace(version))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Cast<string>()
+            .ToArray();
+
+        if (versions.Length == 1)
+        {
+            return versions[0];
+        }
+
+        if (versions.Length > 1)
+        {
+            diagnostics.Add(new SoftwareStateDiagnostic(
+                "inventory.multiple-installed-versions",
+                "Multiple installed versions were detected; the application is installed but no single version is reported."));
+        }
+
+        return null;
+    }
+
+    private static ProviderMatchIndex BuildProviderMatches(
+        IReadOnlyList<SoftwareDetectionTarget> targets,
+        IReadOnlyList<InstalledSoftwareRecord> records,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> providerOwners)
+    {
+        var byApplication = new Dictionary<string, List<InstalledSoftwareRecord>>(StringComparer.Ordinal);
+        var ambiguousTargets = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var record in records.Where(record => record.SourceKind == InstalledSoftwareSourceKind.PackageProvider))
+        {
+            if (string.IsNullOrWhiteSpace(record.ProviderId) ||
+                string.IsNullOrWhiteSpace(record.PackageId) ||
+                string.IsNullOrWhiteSpace(record.PackageSource))
+            {
+                continue;
+            }
+
+            var key = ProviderKey(record.ProviderId, record.PackageSource, record.PackageId);
+            if (!providerOwners.TryGetValue(key, out var owners) || owners.Count == 0)
+            {
+                continue;
+            }
+
+            if (owners.Count > 1)
+            {
+                foreach (var owner in owners)
+                {
+                    ambiguousTargets.Add(owner);
+                }
+
+                continue;
+            }
+
+            Add(byApplication, owners[0], record);
+        }
+
+        return new ProviderMatchIndex(byApplication, ambiguousTargets);
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> BuildProviderOwnerIndex(
+        IReadOnlyList<SoftwareDetectionTarget> targets)
+    {
+        var index = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var target in targets)
+        {
+            foreach (var package in target.ProviderPackages)
+            {
+                var key = ProviderKey(package.ProviderId, package.Source, package.PackageId);
+                if (!index.TryGetValue(key, out var owners))
+                {
+                    owners = [];
+                    index[key] = owners;
+                }
+
+                if (!owners.Contains(target.ApplicationId, StringComparer.Ordinal))
+                {
+                    owners.Add(target.ApplicationId);
+                }
+            }
+        }
+
+        return index.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyList<string>)pair.Value,
+            StringComparer.Ordinal);
+    }
+
+    private static RegistryMatchIndex BuildRegistryMatches(
+        IReadOnlyList<SoftwareDetectionTarget> targets,
+        IReadOnlyList<InstalledSoftwareRecord> records)
+    {
+        var byApplication = new Dictionary<string, List<InstalledSoftwareRecord>>(StringComparer.Ordinal);
+        var ambiguousTargets = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var record in records.Where(record => record.SourceKind == InstalledSoftwareSourceKind.Registry))
+        {
+            var owners = targets
+                .Where(target => RegistryRecordMatchesTarget(record, target))
+                .Select(target => target.ApplicationId)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            if (owners.Length == 0)
+            {
+                continue;
+            }
+
+            if (owners.Length > 1)
+            {
+                foreach (var owner in owners)
+                {
+                    ambiguousTargets.Add(owner);
+                }
+
+                continue;
+            }
+
+            Add(byApplication, owners[0], record);
+        }
+
+        foreach (var ambiguousTarget in ambiguousTargets)
+        {
+            byApplication.Remove(ambiguousTarget);
+        }
+
+        return new RegistryMatchIndex(byApplication, ambiguousTargets);
+    }
+
+    private static bool RegistryRecordMatchesTarget(
+        InstalledSoftwareRecord record,
+        SoftwareDetectionTarget target)
+    {
+        var displayName = Normalize(record.DisplayName);
+        if (displayName.Length == 0)
+        {
+            return false;
+        }
+
+        var explicitNames = target.RegistryDisplayNames
+            .Select(Normalize)
+            .Where(value => value.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (explicitNames.Contains(displayName))
+        {
+            return PublisherCompatible(record.Publisher, target.Publisher);
+        }
+
+        return displayName == Normalize(target.DisplayName) &&
+               PublisherCompatible(record.Publisher, target.Publisher);
+    }
+
+    private static bool PublisherCompatible(string? observedPublisher, string expectedPublisher)
+    {
+        var expected = Normalize(expectedPublisher);
+        var observed = Normalize(observedPublisher);
+
+        if (expected.Length == 0)
+        {
+            return true;
+        }
+
+        return observed.Length > 0 && observed == expected;
+    }
+
+    private static string ProviderKey(string providerId, string source, string packageId) =>
+        $"{Normalize(providerId)}\u001f{Normalize(source)}\u001f{Normalize(packageId)}";
+
+    private static void Add(
+        IDictionary<string, List<InstalledSoftwareRecord>> index,
+        string applicationId,
+        InstalledSoftwareRecord record)
+    {
+        if (!index.TryGetValue(applicationId, out var records))
+        {
+            records = [];
+            index[applicationId] = records;
+        }
+
+        if (!records.Contains(record))
+        {
+            records.Add(record);
+        }
+    }
+
+    private static void ValidateTargets(IReadOnlyList<SoftwareDetectionTarget> targets)
+    {
+        var duplicates = targets
+            .GroupBy(target => target.ApplicationId, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToArray();
+
+        if (duplicates.Length > 0)
+        {
+            throw new ArgumentException(
+                $"Software detection targets contain duplicate application IDs: {string.Join(", ", duplicates)}",
+                nameof(targets));
+        }
+    }
+
+    private static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        return WhitespacePattern()
+            .Replace(value.Trim(), " ")
+            .ToLowerInvariant();
+    }
+
+    [GeneratedRegex("\\s+", RegexOptions.CultureInvariant)]
+    private static partial Regex WhitespacePattern();
+
+    private sealed record ProviderMatchIndex(
+        IReadOnlyDictionary<string, List<InstalledSoftwareRecord>> ByApplication,
+        IReadOnlySet<string> AmbiguousTargets);
+
+    private sealed record RegistryMatchIndex(
+        IReadOnlyDictionary<string, List<InstalledSoftwareRecord>> ByApplication,
+        IReadOnlySet<string> AmbiguousTargets);
+}

--- a/tests/AgenStart.Platform.Windows.Tests/AgenStart.Platform.Windows.Tests.csproj
+++ b/tests/AgenStart.Platform.Windows.Tests/AgenStart.Platform.Windows.Tests.csproj
@@ -18,5 +18,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AgenStart.Platform.Windows\AgenStart.Platform.Windows.csproj" />
+    <ProjectReference Include="..\..\src\AgenStart.SoftwareInventory\AgenStart.SoftwareInventory.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Fixtures\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/AgenStart.Platform.Windows.Tests/Fixtures/winget-installed-export.json
+++ b/tests/AgenStart.Platform.Windows.Tests/Fixtures/winget-installed-export.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://aka.ms/winget-packages.schema.2.0.json",
+  "CreationDate": "2026-09-03T00:00:00.000-00:00",
+  "Sources": [
+    {
+      "Packages": [
+        {
+          "PackageIdentifier": "Git.Git",
+          "Version": "2.51.0"
+        },
+        {
+          "PackageIdentifier": "Microsoft.VisualStudioCode",
+          "Version": "1.103.2",
+          "Scope": "user"
+        },
+        {
+          "PackageIdentifier": "VideoLAN.VLC"
+        },
+        {
+          "PackageIdentifier": ""
+        },
+        {
+          "Unexpected": "ignored"
+        }
+      ],
+      "SourceDetails": {
+        "Argument": "https://cdn.winget.microsoft.com/cache",
+        "Identifier": "Microsoft.Winget.Source_8wekyb3d8bbwe",
+        "Name": "winget",
+        "Type": "Microsoft.PreIndexed.Package"
+      }
+    },
+    {
+      "Packages": [
+        {
+          "PackageIdentifier": "9NKSQGP7F2NH",
+          "Version": "125.0.0"
+        }
+      ],
+      "SourceDetails": {
+        "Name": "msstore"
+      }
+    }
+  ]
+}

--- a/tests/AgenStart.Platform.Windows.Tests/InstalledSoftwareInventoryTests.cs
+++ b/tests/AgenStart.Platform.Windows.Tests/InstalledSoftwareInventoryTests.cs
@@ -1,0 +1,280 @@
+using AgenStart.PackageManagement;
+using AgenStart.Platform.Windows.SoftwareInventory;
+using AgenStart.Platform.Windows.WinGet;
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Platform.Windows.Tests;
+
+public sealed class InstalledSoftwareInventoryTests
+{
+    [Fact]
+    public void WinGetExportParser_UsesOnlyExpectedSourceAndCapturesVersions()
+    {
+        var json = File.ReadAllText(FixturePath("winget-installed-export.json"));
+
+        var records = WinGetInstalledSoftwareExportParser.Parse(json, "winget");
+
+        Assert.Equal(3, records.Count);
+
+        var git = Assert.Single(records.Where(record => record.PackageId == "Git.Git"));
+        Assert.Equal("2.51.0", git.Version);
+        Assert.Equal(PackageProviderIds.WinGet, git.ProviderId);
+        Assert.Equal("winget", git.PackageSource);
+
+        var vscode = Assert.Single(records.Where(record => record.PackageId == "Microsoft.VisualStudioCode"));
+        Assert.Equal("1.103.2", vscode.Version);
+        Assert.Equal(InstalledSoftwareScope.User, vscode.Scope);
+
+        var vlc = Assert.Single(records.Where(record => record.PackageId == "VideoLAN.VLC"));
+        Assert.Null(vlc.Version);
+    }
+
+    [Fact]
+    public void WinGetExportParser_CanReadMicrosoftStoreSeparately()
+    {
+        var json = File.ReadAllText(FixturePath("winget-installed-export.json"));
+
+        var records = WinGetInstalledSoftwareExportParser.Parse(json, "msstore");
+
+        var storePackage = Assert.Single(records);
+        Assert.Equal("9NKSQGP7F2NH", storePackage.PackageId);
+        Assert.Equal("msstore", storePackage.PackageSource);
+    }
+
+    [Fact]
+    public void WinGetExportCommand_IsExactToTrustedSourceAndOwnedOutput()
+    {
+        var output = Path.Combine(Path.GetTempPath(), "AgenStart", "inventory-test.json");
+
+        var command = WinGetCommandBuilder.BuildExportInstalled("winget", output);
+
+        Assert.Equal(
+            [
+                "export",
+                "--output", output,
+                "--source", "winget",
+                "--include-versions",
+                "--disable-interactivity"
+            ],
+            command.Arguments);
+
+        Assert.Throws<ArgumentException>(() =>
+            WinGetCommandBuilder.BuildExportInstalled("custom-source", output));
+    }
+
+    [Fact]
+    public void Resolver_ConfirmsExactProviderIdentityAndVersion()
+    {
+        var target = Target(
+            "visual-studio-code",
+            "Visual Studio Code",
+            "Microsoft",
+            "Microsoft.VisualStudioCode");
+        var record = ProviderRecord(
+            "Microsoft.VisualStudioCode",
+            "1.103.2");
+        var snapshot = Snapshot(
+            [record, ProviderRecord("Unknown.Publisher.App", "9.0")],
+            [CompleteProviderSource("winget")]);
+
+        var result = new SoftwareStateResolver().Resolve([target], snapshot);
+
+        var state = Assert.Single(result.Applications);
+        Assert.Equal(SoftwarePresenceState.Installed, state.State);
+        Assert.Equal("1.103.2", state.InstalledVersion);
+        Assert.Same(record, Assert.Single(state.Evidence));
+        Assert.Equal(1, result.UnmappedRecordCount);
+    }
+
+    [Fact]
+    public void Resolver_UsesExactRegistryNameAndPublisherAsIndependentEvidence()
+    {
+        var target = new SoftwareDetectionTarget(
+            "vlc",
+            "VLC media player",
+            "VideoLAN",
+            [],
+            ["VLC media player"]);
+        var record = new InstalledSoftwareRecord(
+            InstalledSoftwareSourceKind.Registry,
+            SoftwareInventorySourceIds.WindowsRegistry,
+            "VLC media player",
+            "VideoLAN",
+            "3.0.21",
+            InstalledSoftwareScope.Machine);
+
+        var result = new SoftwareStateResolver().Resolve(
+            [target],
+            Snapshot([record], [CompleteRegistry()]));
+
+        var state = Assert.Single(result.Applications);
+        Assert.Equal(SoftwarePresenceState.Installed, state.State);
+        Assert.Equal("3.0.21", state.InstalledVersion);
+        Assert.Empty(state.Diagnostics);
+    }
+
+    [Fact]
+    public void Resolver_DoesNotSilentlyConfirmAmbiguousRegistryMatch()
+    {
+        var first = new SoftwareDetectionTarget(
+            "example-one",
+            "Example App",
+            "Example Publisher",
+            [],
+            ["Example App"]);
+        var second = new SoftwareDetectionTarget(
+            "example-two",
+            "Example App",
+            "Example Publisher",
+            [],
+            ["Example App"]);
+        var record = new InstalledSoftwareRecord(
+            InstalledSoftwareSourceKind.Registry,
+            SoftwareInventorySourceIds.WindowsRegistry,
+            "Example App",
+            "Example Publisher",
+            "1.0");
+
+        var result = new SoftwareStateResolver().Resolve(
+            [first, second],
+            Snapshot([record], [CompleteRegistry()]));
+
+        Assert.All(result.Applications, application =>
+        {
+            Assert.Equal(SoftwarePresenceState.Unknown, application.State);
+            Assert.Contains(
+                application.Diagnostics,
+                diagnostic => diagnostic.Code == "inventory.ambiguous-registry-match");
+        });
+        Assert.Equal(1, result.UnmappedRecordCount);
+    }
+
+    [Fact]
+    public void Resolver_UsesSourceCompletenessToDistinguishMissingFromUnknown()
+    {
+        var target = Target("git", "Git", "Git Project", "Git.Git");
+        var resolver = new SoftwareStateResolver();
+
+        var missing = resolver.Resolve(
+            [target],
+            Snapshot([], [CompleteProviderSource("winget")]));
+        var unknown = resolver.Resolve(
+            [target],
+            Snapshot(
+                [],
+                [new InventorySourceStatus(
+                    SoftwareInventorySourceIds.ForPackageProvider(PackageProviderIds.WinGet, "winget"),
+                    InventorySourceState.Partial,
+                    "fixture.partial")]));
+
+        Assert.Equal(SoftwarePresenceState.Missing, Assert.Single(missing.Applications).State);
+        Assert.Equal(SoftwarePresenceState.Unknown, Assert.Single(unknown.Applications).State);
+    }
+
+    [Fact]
+    public void Resolver_KeepsInstalledStateWhenDifferentVersionsAreObserved()
+    {
+        var target = Target("git", "Git", "Git Project", "Git.Git");
+        var snapshot = Snapshot(
+            [
+                ProviderRecord("Git.Git", "2.50.0"),
+                ProviderRecord("Git.Git", "2.51.0")
+            ],
+            [CompleteProviderSource("winget")]);
+
+        var state = Assert.Single(new SoftwareStateResolver().Resolve([target], snapshot).Applications);
+
+        Assert.Equal(SoftwarePresenceState.Installed, state.State);
+        Assert.Null(state.InstalledVersion);
+        Assert.Contains(
+            state.Diagnostics,
+            diagnostic => diagnostic.Code == "inventory.multiple-installed-versions");
+    }
+
+    [Fact]
+    public async Task CompositeProvider_MergesCollectorsDeduplicatesRecordsAndPreservesStatuses()
+    {
+        var capturedAt = new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+        var registryRecord = new InstalledSoftwareRecord(
+            InstalledSoftwareSourceKind.Registry,
+            SoftwareInventorySourceIds.WindowsRegistry,
+            "7-Zip",
+            "Igor Pavlov",
+            "25.01");
+        var wingetRecord = ProviderRecord("7zip.7zip", "25.01");
+
+        var provider = new CompositeInstalledSoftwareInventoryProvider(
+        [
+            new FakeCollector(new InstalledSoftwareCollectionResult(
+                [registryRecord],
+                [CompleteRegistry()])),
+            new FakeCollector(new InstalledSoftwareCollectionResult(
+                [registryRecord, wingetRecord],
+                [CompleteProviderSource("winget")]))
+        ],
+        new FixedTimeProvider(capturedAt));
+
+        var snapshot = await provider.CaptureAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, snapshot.Records.Count);
+        Assert.Equal(2, snapshot.Sources.Count);
+        Assert.Equal(capturedAt, snapshot.CapturedAtUtc);
+    }
+
+    private static string FixturePath(string fileName) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", fileName);
+
+    private static SoftwareDetectionTarget Target(
+        string id,
+        string displayName,
+        string publisher,
+        string packageId) =>
+        new(
+            id,
+            displayName,
+            publisher,
+            [new ProviderPackageReference(PackageProviderIds.WinGet, packageId, "winget")],
+            [displayName]);
+
+    private static InstalledSoftwareRecord ProviderRecord(
+        string packageId,
+        string? version) =>
+        new(
+            InstalledSoftwareSourceKind.PackageProvider,
+            SoftwareInventorySourceIds.ForPackageProvider(PackageProviderIds.WinGet, "winget"),
+            packageId,
+            Version: version,
+            ProviderId: PackageProviderIds.WinGet,
+            PackageId: packageId,
+            PackageSource: "winget");
+
+    private static InventorySourceStatus CompleteProviderSource(string source) =>
+        new(
+            SoftwareInventorySourceIds.ForPackageProvider(PackageProviderIds.WinGet, source),
+            InventorySourceState.Complete);
+
+    private static InventorySourceStatus CompleteRegistry() =>
+        new(
+            SoftwareInventorySourceIds.WindowsRegistry,
+            InventorySourceState.Complete);
+
+    private static InstalledSoftwareSnapshot Snapshot(
+        IReadOnlyList<InstalledSoftwareRecord> records,
+        IReadOnlyList<InventorySourceStatus> sources) =>
+        new(records, sources, DateTimeOffset.UnixEpoch);
+
+    private sealed class FakeCollector(InstalledSoftwareCollectionResult result) : IInstalledSoftwareCollector
+    {
+        public Task<InstalledSoftwareCollectionResult> CollectAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(result);
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/tests/AgenStart.Platform.Windows.Tests/InstalledSoftwareInventoryTests.cs
+++ b/tests/AgenStart.Platform.Windows.Tests/InstalledSoftwareInventoryTests.cs
@@ -16,16 +16,16 @@ public sealed class InstalledSoftwareInventoryTests
 
         Assert.Equal(3, records.Count);
 
-        var git = Assert.Single(records.Where(record => record.PackageId == "Git.Git"));
+        var git = Assert.Single(records, record => record.PackageId == "Git.Git");
         Assert.Equal("2.51.0", git.Version);
         Assert.Equal(PackageProviderIds.WinGet, git.ProviderId);
         Assert.Equal("winget", git.PackageSource);
 
-        var vscode = Assert.Single(records.Where(record => record.PackageId == "Microsoft.VisualStudioCode"));
+        var vscode = Assert.Single(records, record => record.PackageId == "Microsoft.VisualStudioCode");
         Assert.Equal("1.103.2", vscode.Version);
         Assert.Equal(InstalledSoftwareScope.User, vscode.Scope);
 
-        var vlc = Assert.Single(records.Where(record => record.PackageId == "VideoLAN.VLC"));
+        var vlc = Assert.Single(records, record => record.PackageId == "VideoLAN.VLC");
         Assert.Null(vlc.Version);
     }
 


### PR DESCRIPTION
## Summary

Implements installed-software detection for AgenStart Windows MVP.

### Inventory sources
- reads Windows uninstall registry in read-only mode across HKLM/HKCU and 32/64-bit views
- uses structured `winget export` JSON for trusted `winget` and `msstore` sources
- captures installed version and scope when available
- never reads personal user files

### Normalization
- introduces normalized installed-software contracts and source health states
- matches exact provider identity using provider + source + package ID
- supports exact registry display-name aliases with publisher validation
- distinguishes `Installed`, `Missing`, and `Unknown`
- ambiguous matches fail conservatively instead of becoming confirmed matches
- unknown installed software is retained without breaking catalogue resolution

### Composition
- adds a composite inventory provider that merges and deduplicates collectors
- adds the Windows entrypoint combining Registry + WinGet collectors

### Verification
- fixture-based WinGet export tests
- tests exact provider and registry matches
- tests ambiguous registry identities
- tests Missing vs Unknown based on source completeness
- tests multiple installed versions
- tests collector aggregation/deduplication
- extends the Windows CI gate to the new SoftwareInventory module

### Documentation
- adds `docs/architecture/installed-software-inventory.md`

Closes #5