### PR TITLE
feat: build explainable recommendation engine

### DIFF
--- a/.github/workflows/recommendation-tests.yml
+++ b/.github/workflows/recommendation-tests.yml
@@ -1,0 +1,34 @@
+name: Recommendation tests
+
+on:
+  pull_request:
+    paths:
+      - "src/AgenStart.Core/**"
+      - "src/AgenStart.Recommendations/**"
+      - "src/AgenStart.SoftwareInventory/**"
+      - "tests/AgenStart.Recommendations.Tests/**"
+      - "docs/architecture/recommendation-engine.md"
+      - ".github/workflows/recommendation-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore
+        run: dotnet restore tests/AgenStart.Recommendations.Tests/AgenStart.Recommendations.Tests.csproj
+
+      - name: Test
+        run: dotnet test tests/AgenStart.Recommendations.Tests/AgenStart.Recommendations.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -1,0 +1,233 @@
+# Explainable recommendation engine
+
+Status: Implemented for MVP rules
+
+Related issue: #6
+
+## Purpose
+
+The recommendation engine decides which curated applications are appropriate for the selected AgenStart profile using only normalized domain state:
+
+- selected user profile;
+- cross-platform machine capabilities;
+- normalized installed-software state;
+- curated catalogue recommendation metadata and constraints.
+
+The engine is pure domain logic. It does not launch installers, invoke WinGet, access the Registry, show UI, or mutate the machine.
+
+## Dependency boundary
+
+```text
+AgenStart UI / Application
+        |
+        v
+RecommendationEngine
+   |            |
+   v            v
+AgenStart.Core  AgenStart.SoftwareInventory
+   |
+   +-- MachineSnapshot
+   `-- catalogue recommendation contracts
+```
+
+`AgenStart.Core` has no dependency on Avalonia, WinGet, Windows APIs or the software-inventory implementation.
+
+## Supported profiles
+
+The initial profiles match the catalogue contract:
+
+```text
+Personal
+Development
+Business
+Creation
+Training
+```
+
+A catalogue application participates in a plan only when it has exactly one recommendation rule for the selected profile.
+
+Recommendation levels are:
+
+```text
+Essential
+Recommended
+Optional
+```
+
+Essential and Recommended applications are preselected when all safety/compatibility checks pass. Optional applications remain visible but are not preselected.
+
+Preselection is only a recommendation. The user validates and may change the final selection before installation; execution is owned by later installation-planning/orchestration work.
+
+## Explainability
+
+Every decision keeps the catalogue `reasonKey` and exposes human-readable reasons describing why the application is present and why it was selected, excluded or withheld.
+
+Examples:
+
+- profile fit;
+- already installed;
+- installed state could not be verified;
+- insufficient RAM;
+- insufficient storage;
+- unsupported architecture;
+- GPU required but unavailable;
+- compatibility value unknown;
+- catalogue lifecycle unavailable;
+- conflict with an installed application;
+- conflict with a higher-priority recommendation;
+- machine meets minimum but not recommended capability.
+
+The engine does not rely on opaque scores for MVP decisions.
+
+## Deterministic rule order
+
+For an application that belongs to the selected profile, the engine applies rules in a stable order:
+
+1. handle normalized installed-software state;
+2. reject deprecated/blocked catalogue entries for new installation;
+3. verify platform support;
+4. enforce architecture constraints;
+5. enforce minimum RAM;
+6. enforce minimum free storage on the system drive;
+7. enforce required GPU capability;
+8. add non-blocking advisories for recommended capabilities;
+9. resolve conflicts deterministically;
+10. produce the suggested default selection.
+
+The same normalized input must produce the same ordered plan.
+
+## Installed software behavior
+
+The engine consumes the states produced by issue #5:
+
+### Installed
+
+The application is returned as `AlreadyInstalled` and is never preselected for another installation.
+
+### Missing
+
+The engine may recommend the application when catalogue and machine rules pass.
+
+### Unknown
+
+The application is returned as `InventoryUnknown` and is not preselected. AgenStart does not guess that an application is missing and thereby create a duplicate install proposal.
+
+If the recommendation engine receives no normalized software state at all for a profile application, it uses the same fail-conservative behavior.
+
+## Capability behavior
+
+Minimum catalogue requirements are hard constraints.
+
+### Known below minimum
+
+The decision is `Incompatible`.
+
+### Required value unknown
+
+The decision is `CompatibilityUnknown` and is not preselected. This follows the machine-inventory rule that unknown capability values are never silently interpreted as compatible.
+
+### Recommended value not reached
+
+If minimum requirements pass but a known value is below the catalogue's recommended threshold, the application remains recommendable with an explanatory advisory.
+
+## Platform and architecture
+
+Catalogue platform support must be explicitly `Supported` for the detected platform.
+
+`Planned`, `Unsupported`, or absent platform support cannot enter the default installation selection.
+
+Machine architecture must satisfy both the platform-support architecture list and the application's minimum architecture list. An unknown architecture produces `CompatibilityUnknown`.
+
+## GPU capability
+
+GPU requirements use an explicit normalized state:
+
+```text
+Available
+Unavailable
+Unknown
+```
+
+A required unavailable GPU is incompatible. A required unknown GPU state is unverified and therefore not preselected.
+
+## Conflict handling
+
+Catalogue conflicts use canonical AgenStart application IDs.
+
+### Conflict with installed software
+
+A recommendation conflicting with an already-installed application is marked `Conflict` and withheld from default selection.
+
+### Conflict between recommendations
+
+The engine resolves conflicting candidates deterministically:
+
+1. Essential beats Recommended;
+2. Recommended beats Optional;
+3. equal levels use canonical application ID as the stable tie-breaker.
+
+The losing recommendation remains visible as `Conflict` with an explanation.
+
+This prevents contradictory default plans while preserving user visibility into the decision.
+
+## Invalid catalogue state
+
+The engine fails closed when it receives invalid normalized catalogue input, including:
+
+- duplicate canonical application IDs;
+- duplicate recommendation rules for the same application/profile;
+- self dependencies/conflicts;
+- dependency/conflict references to unknown canonical IDs;
+- duplicate platform support rules for the active platform;
+- negative capability requirements.
+
+Full JSON Schema and catalogue cross-entry validation remain part of the catalogue boundary; the engine still rejects invalid domain input rather than relying on callers to be perfect.
+
+## Dependencies
+
+Catalogue dependency references are validated in this issue, but dependency expansion into an executable installation plan is intentionally not performed here.
+
+Why:
+
+```text
+recommendation = what is appropriate for the user
+installation plan = exact ordered work that will be executed
+```
+
+Dependency expansion, execution ordering, retries and provider operations belong with installation orchestration (#7). This avoids making the recommendation engine an installer in disguise.
+
+## Machine model initialization
+
+Issue #6 initializes `AgenStart.Core` with the cross-platform machine contracts specified by the machine-inventory architecture document:
+
+- PlatformSnapshot
+- CpuSnapshot
+- MemorySnapshot
+- GpuSnapshot
+- StorageSnapshot
+- PackageManagerSnapshot
+- CapabilitySnapshot
+- MachineSnapshot
+
+Windows collectors remain outside Core. Future Windows machine-inventory implementation maps platform APIs into these contracts; future macOS support can do the same without changing recommendation rules.
+
+## Testing
+
+The recommendation test suite is platform-independent and runs on Linux with .NET 10 because the engine has no Windows dependency.
+
+Representative scenarios cover:
+
+- all five initial profiles;
+- human-readable reasons;
+- already-installed applications;
+- unknown installed state;
+- insufficient and unknown RAM;
+- GPU minimum requirements;
+- optional/preselection behavior;
+- installed conflicts;
+- deterministic recommendation conflicts;
+- recommended-capability advisories;
+- duplicate catalogue data;
+- applications outside the selected profile.
+
+No test launches an installer or package manager.

--- a/src/AgenStart.Core/AgenStart.Core.csproj
+++ b/src/AgenStart.Core/AgenStart.Core.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/src/AgenStart.Core/Catalogue/ApplicationDefinition.cs
+++ b/src/AgenStart.Core/Catalogue/ApplicationDefinition.cs
@@ -1,0 +1,63 @@
+using AgenStart.Core.Machine;
+
+namespace AgenStart.Core.Catalogue;
+
+public enum UserProfile
+{
+    Personal,
+    Development,
+    Business,
+    Creation,
+    Training
+}
+
+public enum RecommendationLevel
+{
+    Essential,
+    Recommended,
+    Optional
+}
+
+public enum ApplicationLifecycleStatus
+{
+    Active,
+    Deprecated,
+    Blocked
+}
+
+public enum PlatformSupportStatus
+{
+    Supported,
+    Planned,
+    Unsupported
+}
+
+public sealed record ApplicationDefinition(
+    string Id,
+    string Name,
+    ApplicationLifecycleStatus Lifecycle,
+    IReadOnlyList<ProfileRecommendation> Recommendations,
+    ApplicationRequirements Requirements,
+    IReadOnlyList<PlatformSupportRule> PlatformSupport,
+    IReadOnlyList<string> Dependencies,
+    IReadOnlyList<string> Conflicts);
+
+public sealed record ProfileRecommendation(
+    UserProfile Profile,
+    RecommendationLevel Level,
+    string ReasonKey);
+
+public sealed record ApplicationRequirements(
+    CapabilityRequirements Minimum,
+    CapabilityRequirements Recommended);
+
+public sealed record CapabilityRequirements(
+    long? MinRamMiB,
+    long? MinFreeStorageMiB,
+    bool GpuRequired,
+    IReadOnlyList<MachineArchitecture> Architectures);
+
+public sealed record PlatformSupportRule(
+    PlatformKind Platform,
+    PlatformSupportStatus Status,
+    IReadOnlyList<MachineArchitecture> Architectures);

--- a/src/AgenStart.Core/Machine/MachineSnapshot.cs
+++ b/src/AgenStart.Core/Machine/MachineSnapshot.cs
@@ -1,0 +1,104 @@
+namespace AgenStart.Core.Machine;
+
+public enum PlatformKind
+{
+    Unknown,
+    Windows,
+    MacOS
+}
+
+public enum MachineArchitecture
+{
+    Unknown,
+    X86,
+    X64,
+    Arm64
+}
+
+public enum StorageKind
+{
+    Unknown,
+    Fixed,
+    Removable,
+    Network
+}
+
+public enum PackageManagerKind
+{
+    None,
+    WinGet,
+    Homebrew
+}
+
+public enum CapabilityState
+{
+    Available,
+    Unavailable,
+    Unknown,
+    Failed,
+    TimedOut
+}
+
+public enum GpuCapabilityState
+{
+    Available,
+    Unavailable,
+    Unknown
+}
+
+public sealed record MachineSnapshot(
+    PlatformSnapshot Platform,
+    CpuSnapshot Cpu,
+    MemorySnapshot Memory,
+    IReadOnlyList<GpuSnapshot> Gpus,
+    IReadOnlyList<StorageSnapshot> Storage,
+    PackageManagerSnapshot PackageManager,
+    CapabilitySnapshot Capabilities,
+    IReadOnlyList<InventoryDiagnostic> Diagnostics,
+    DateTimeOffset CapturedAtUtc)
+{
+    public StorageSnapshot? SystemDrive =>
+        Storage.FirstOrDefault(static storage => storage.IsSystemDrive);
+}
+
+public sealed record PlatformSnapshot(
+    PlatformKind Kind,
+    string? Edition,
+    string? DisplayVersion,
+    Version? Version,
+    string? Build,
+    string? Revision,
+    MachineArchitecture Architecture,
+    MachineArchitecture ProcessArchitecture);
+
+public sealed record CpuSnapshot(
+    string? Model,
+    MachineArchitecture Architecture,
+    int LogicalProcessorCount);
+
+public sealed record MemorySnapshot(
+    ulong? TotalPhysicalBytes,
+    ulong? AvailablePhysicalBytes);
+
+public sealed record GpuSnapshot(
+    string? Name,
+    string? Vendor);
+
+public sealed record StorageSnapshot(
+    string Root,
+    StorageKind Kind,
+    long? TotalBytes,
+    long? AvailableBytes,
+    bool IsSystemDrive);
+
+public sealed record PackageManagerSnapshot(
+    PackageManagerKind Kind,
+    CapabilityState State,
+    Version? Version);
+
+public sealed record CapabilitySnapshot(
+    GpuCapabilityState Gpu);
+
+public sealed record InventoryDiagnostic(
+    string Code,
+    string Message);

--- a/src/AgenStart.Recommendations/AgenStart.Recommendations.csproj
+++ b/src/AgenStart.Recommendations/AgenStart.Recommendations.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgenStart.Core\AgenStart.Core.csproj" />
+    <ProjectReference Include="..\AgenStart.SoftwareInventory\AgenStart.SoftwareInventory.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AgenStart.Recommendations/RecommendationContracts.cs
+++ b/src/AgenStart.Recommendations/RecommendationContracts.cs
@@ -1,0 +1,46 @@
+using AgenStart.Core.Catalogue;
+using AgenStart.Core.Machine;
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Recommendations;
+
+public enum RecommendationDisposition
+{
+    Recommended,
+    AlreadyInstalled,
+    Incompatible,
+    CompatibilityUnknown,
+    InventoryUnknown,
+    Conflict,
+    Unavailable
+}
+
+public sealed record RecommendationRequest(
+    UserProfile Profile,
+    MachineSnapshot Machine,
+    SoftwareDetectionResult Software,
+    IReadOnlyList<ApplicationDefinition> Applications);
+
+public sealed record RecommendationReason(
+    string Code,
+    string Message);
+
+public sealed record RecommendationDecision(
+    string ApplicationId,
+    string ApplicationName,
+    UserProfile Profile,
+    RecommendationLevel Level,
+    string ProfileReasonKey,
+    RecommendationDisposition Disposition,
+    bool SelectedByDefault,
+    IReadOnlyList<RecommendationReason> Reasons);
+
+public sealed record RecommendationPlan(
+    UserProfile Profile,
+    IReadOnlyList<RecommendationDecision> Decisions)
+{
+    public IReadOnlyList<RecommendationDecision> DefaultSelection =>
+        Decisions
+            .Where(static decision => decision.SelectedByDefault)
+            .ToArray();
+}

--- a/src/AgenStart.Recommendations/RecommendationEngine.cs
+++ b/src/AgenStart.Recommendations/RecommendationEngine.cs
@@ -1,0 +1,701 @@
+using AgenStart.Core.Catalogue;
+using AgenStart.Core.Machine;
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Recommendations;
+
+public sealed class RecommendationEngine
+{
+    private const long BytesPerMiB = 1024L * 1024L;
+
+    public RecommendationPlan Build(RecommendationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Machine);
+        ArgumentNullException.ThrowIfNull(request.Software);
+        ArgumentNullException.ThrowIfNull(request.Applications);
+
+        var applications = BuildApplicationIndex(request.Applications);
+        ValidateGraphReferences(applications);
+        var software = BuildSoftwareIndex(request.Software.Applications);
+
+        var decisions = new List<RecommendationDecision>();
+
+        foreach (var application in applications.Values)
+        {
+            var profileRule = ResolveProfileRule(application, request.Profile);
+            if (profileRule is null)
+            {
+                continue;
+            }
+
+            decisions.Add(Evaluate(
+                application,
+                profileRule,
+                request.Profile,
+                request.Machine,
+                software));
+        }
+
+        ResolveInstalledConflicts(decisions, applications, software);
+        ResolveRecommendationConflicts(decisions, applications);
+
+        return new RecommendationPlan(
+            request.Profile,
+            decisions
+                .OrderBy(decision => LevelRank(decision.Level))
+                .ThenBy(decision => decision.ApplicationName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(decision => decision.ApplicationId, StringComparer.OrdinalIgnoreCase)
+                .ToArray());
+    }
+
+    private static Dictionary<string, ApplicationDefinition> BuildApplicationIndex(
+        IReadOnlyList<ApplicationDefinition> applications)
+    {
+        var index = new Dictionary<string, ApplicationDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var application in applications)
+        {
+            ArgumentNullException.ThrowIfNull(application);
+            var id = RequireText(application.Id, "Application id");
+            RequireText(application.Name, $"Application name for {id}");
+
+            if (!index.TryAdd(id, application))
+            {
+                throw new InvalidOperationException(
+                    $"Duplicate canonical application id: {id}.");
+            }
+
+            ValidateRequirements(application.Requirements.Minimum, id, "minimum");
+            ValidateRequirements(application.Requirements.Recommended, id, "recommended");
+        }
+
+        return index;
+    }
+
+    private static Dictionary<string, DetectedApplicationState> BuildSoftwareIndex(
+        IReadOnlyList<DetectedApplicationState> states)
+    {
+        var index = new Dictionary<string, DetectedApplicationState>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var state in states)
+        {
+            ArgumentNullException.ThrowIfNull(state);
+            var id = RequireText(state.ApplicationId, "Software-state application id");
+            if (!index.TryAdd(id, state))
+            {
+                throw new InvalidOperationException(
+                    $"Duplicate normalized software state for application: {id}.");
+            }
+        }
+
+        return index;
+    }
+
+    private static void ValidateGraphReferences(
+        IReadOnlyDictionary<string, ApplicationDefinition> applications)
+    {
+        foreach (var application in applications.Values)
+        {
+            foreach (var dependency in application.Dependencies)
+            {
+                var id = RequireText(dependency, $"Dependency id for {application.Id}");
+                if (string.Equals(id, application.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Application {application.Id} cannot depend on itself.");
+                }
+
+                if (!applications.ContainsKey(id))
+                {
+                    throw new InvalidOperationException(
+                        $"Application {application.Id} references unknown dependency {id}.");
+                }
+            }
+
+            foreach (var conflict in application.Conflicts)
+            {
+                var id = RequireText(conflict, $"Conflict id for {application.Id}");
+                if (string.Equals(id, application.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Application {application.Id} cannot conflict with itself.");
+                }
+
+                if (!applications.ContainsKey(id))
+                {
+                    throw new InvalidOperationException(
+                        $"Application {application.Id} references unknown conflict {id}.");
+                }
+            }
+        }
+    }
+
+    private static ProfileRecommendation? ResolveProfileRule(
+        ApplicationDefinition application,
+        UserProfile profile)
+    {
+        var matches = application.Recommendations
+            .Where(rule => rule.Profile == profile)
+            .ToArray();
+
+        if (matches.Length > 1)
+        {
+            throw new InvalidOperationException(
+                $"Application {application.Id} contains duplicate recommendations for profile {profile}.");
+        }
+
+        if (matches.Length == 0)
+        {
+            return null;
+        }
+
+        var rule = matches[0];
+        RequireText(rule.ReasonKey, $"Recommendation reason key for {application.Id}/{profile}");
+        return rule;
+    }
+
+    private static RecommendationDecision Evaluate(
+        ApplicationDefinition application,
+        ProfileRecommendation profileRule,
+        UserProfile profile,
+        MachineSnapshot machine,
+        IReadOnlyDictionary<string, DetectedApplicationState> software)
+    {
+        var reasons = new List<RecommendationReason>
+        {
+            new(
+                $"profile.{profileRule.ReasonKey}",
+                ProfileMessage(application.Name, profile, profileRule.Level))
+        };
+
+        if (software.TryGetValue(application.Id, out var installedState))
+        {
+            if (installedState.State == SoftwarePresenceState.Installed)
+            {
+                reasons.Add(new RecommendationReason(
+                    "software.already-installed",
+                    installedState.InstalledVersion is { Length: > 0 } version
+                        ? $"{application.Name} is already installed (version {version})."
+                        : $"{application.Name} is already installed."));
+
+                if (application.Lifecycle != ApplicationLifecycleStatus.Active)
+                {
+                    reasons.Add(LifecycleReason(application));
+                }
+
+                return Decision(
+                    application,
+                    profile,
+                    profileRule,
+                    RecommendationDisposition.AlreadyInstalled,
+                    false,
+                    reasons);
+            }
+
+            if (installedState.State == SoftwarePresenceState.Unknown)
+            {
+                reasons.Add(new RecommendationReason(
+                    "software.presence-unknown",
+                    $"AgenStart cannot safely confirm whether {application.Name} is already installed, so it will not preselect another installation."));
+
+                return Decision(
+                    application,
+                    profile,
+                    profileRule,
+                    RecommendationDisposition.InventoryUnknown,
+                    false,
+                    reasons);
+            }
+        }
+        else
+        {
+            reasons.Add(new RecommendationReason(
+                "software.state-missing",
+                $"No normalized installed-software state is available for {application.Name}; AgenStart will not guess that it is missing."));
+
+            return Decision(
+                application,
+                profile,
+                profileRule,
+                RecommendationDisposition.InventoryUnknown,
+                false,
+                reasons);
+        }
+
+        if (application.Lifecycle != ApplicationLifecycleStatus.Active)
+        {
+            reasons.Add(LifecycleReason(application));
+            return Decision(
+                application,
+                profile,
+                profileRule,
+                RecommendationDisposition.Unavailable,
+                false,
+                reasons);
+        }
+
+        var compatibility = EvaluateCompatibility(application, machine);
+        reasons.AddRange(compatibility.Reasons);
+
+        if (compatibility.HasHardFailure)
+        {
+            return Decision(
+                application,
+                profile,
+                profileRule,
+                RecommendationDisposition.Incompatible,
+                false,
+                reasons);
+        }
+
+        if (compatibility.HasUnknown)
+        {
+            return Decision(
+                application,
+                profile,
+                profileRule,
+                RecommendationDisposition.CompatibilityUnknown,
+                false,
+                reasons);
+        }
+
+        AddRecommendedCapabilityAdvisories(application, machine, reasons);
+
+        return Decision(
+            application,
+            profile,
+            profileRule,
+            RecommendationDisposition.Recommended,
+            profileRule.Level != RecommendationLevel.Optional,
+            reasons);
+    }
+
+    private static CompatibilityResult EvaluateCompatibility(
+        ApplicationDefinition application,
+        MachineSnapshot machine)
+    {
+        var reasons = new List<RecommendationReason>();
+        var hardFailure = false;
+        var unknown = false;
+
+        var platformRule = application.PlatformSupport
+            .Where(rule => rule.Platform == machine.Platform.Kind)
+            .ToArray();
+
+        if (machine.Platform.Kind == PlatformKind.Unknown)
+        {
+            unknown = true;
+            reasons.Add(new RecommendationReason(
+                "capability.platform-unknown",
+                $"The operating-system platform is unknown, so compatibility for {application.Name} cannot be verified."));
+        }
+        else if (platformRule.Length == 0)
+        {
+            hardFailure = true;
+            reasons.Add(new RecommendationReason(
+                "capability.platform-unsupported",
+                $"{application.Name} is not supported by the catalogue on {machine.Platform.Kind}."));
+        }
+        else
+        {
+            if (platformRule.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Application {application.Id} contains duplicate platform support rules for {machine.Platform.Kind}.");
+            }
+
+            var support = platformRule[0];
+            if (support.Status != PlatformSupportStatus.Supported)
+            {
+                hardFailure = true;
+                reasons.Add(new RecommendationReason(
+                    "capability.platform-unsupported",
+                    support.Status == PlatformSupportStatus.Planned
+                        ? $"{application.Name} support for {machine.Platform.Kind} is planned but not currently available."
+                        : $"{application.Name} is unsupported on {machine.Platform.Kind}."));
+            }
+            else
+            {
+                EvaluateArchitecture(
+                    application,
+                    machine.Platform.Architecture,
+                    support.Architectures,
+                    application.Requirements.Minimum.Architectures,
+                    reasons,
+                    ref hardFailure,
+                    ref unknown);
+            }
+        }
+
+        EvaluateRam(
+            application,
+            machine.Memory.TotalPhysicalBytes,
+            application.Requirements.Minimum.MinRamMiB,
+            reasons,
+            ref hardFailure,
+            ref unknown);
+
+        EvaluateStorage(
+            application,
+            machine.SystemDrive?.AvailableBytes,
+            application.Requirements.Minimum.MinFreeStorageMiB,
+            reasons,
+            ref hardFailure,
+            ref unknown);
+
+        if (application.Requirements.Minimum.GpuRequired)
+        {
+            switch (machine.Capabilities.Gpu)
+            {
+                case GpuCapabilityState.Available:
+                    break;
+                case GpuCapabilityState.Unavailable:
+                    hardFailure = true;
+                    reasons.Add(new RecommendationReason(
+                        "capability.gpu-required",
+                        $"{application.Name} requires a GPU, but this machine reports no usable GPU capability."));
+                    break;
+                default:
+                    unknown = true;
+                    reasons.Add(new RecommendationReason(
+                        "capability.gpu-unknown",
+                        $"{application.Name} requires a GPU, but GPU capability could not be verified."));
+                    break;
+            }
+        }
+
+        return new CompatibilityResult(hardFailure, unknown, reasons);
+    }
+
+    private static void EvaluateArchitecture(
+        ApplicationDefinition application,
+        MachineArchitecture architecture,
+        IReadOnlyList<MachineArchitecture> platformArchitectures,
+        IReadOnlyList<MachineArchitecture> minimumArchitectures,
+        ICollection<RecommendationReason> reasons,
+        ref bool hardFailure,
+        ref bool unknown)
+    {
+        var allowed = platformArchitectures
+            .Intersect(minimumArchitectures.Count > 0 ? minimumArchitectures : platformArchitectures)
+            .Distinct()
+            .ToArray();
+
+        if (allowed.Length == 0)
+        {
+            hardFailure = true;
+            reasons.Add(new RecommendationReason(
+                "capability.architecture-no-valid-target",
+                $"{application.Name} has no valid architecture for the current catalogue/platform rules."));
+            return;
+        }
+
+        if (architecture == MachineArchitecture.Unknown)
+        {
+            unknown = true;
+            reasons.Add(new RecommendationReason(
+                "capability.architecture-unknown",
+                $"The machine architecture is unknown, so {application.Name} compatibility cannot be verified."));
+            return;
+        }
+
+        if (!allowed.Contains(architecture))
+        {
+            hardFailure = true;
+            reasons.Add(new RecommendationReason(
+                "capability.architecture-unsupported",
+                $"{application.Name} does not support the detected {architecture} architecture."));
+        }
+    }
+
+    private static void EvaluateRam(
+        ApplicationDefinition application,
+        ulong? totalBytes,
+        long? requiredMiB,
+        ICollection<RecommendationReason> reasons,
+        ref bool hardFailure,
+        ref bool unknown)
+    {
+        if (requiredMiB is null or <= 0)
+        {
+            return;
+        }
+
+        if (totalBytes is null)
+        {
+            unknown = true;
+            reasons.Add(new RecommendationReason(
+                "capability.ram-unknown",
+                $"{application.Name} requires at least {requiredMiB} MiB of RAM, but total memory could not be verified."));
+            return;
+        }
+
+        var availableMiB = totalBytes.Value / (ulong)BytesPerMiB;
+        if (availableMiB < (ulong)requiredMiB.Value)
+        {
+            hardFailure = true;
+            reasons.Add(new RecommendationReason(
+                "capability.ram-insufficient",
+                $"{application.Name} requires at least {requiredMiB} MiB of RAM; this machine reports {availableMiB} MiB."));
+        }
+    }
+
+    private static void EvaluateStorage(
+        ApplicationDefinition application,
+        long? availableBytes,
+        long? requiredMiB,
+        ICollection<RecommendationReason> reasons,
+        ref bool hardFailure,
+        ref bool unknown)
+    {
+        if (requiredMiB is null or <= 0)
+        {
+            return;
+        }
+
+        if (availableBytes is null)
+        {
+            unknown = true;
+            reasons.Add(new RecommendationReason(
+                "capability.storage-unknown",
+                $"{application.Name} requires at least {requiredMiB} MiB of free storage, but system-drive free space could not be verified."));
+            return;
+        }
+
+        if (availableBytes.Value < 0)
+        {
+            unknown = true;
+            reasons.Add(new RecommendationReason(
+                "capability.storage-invalid",
+                $"System-drive free space is invalid, so {application.Name} compatibility cannot be verified."));
+            return;
+        }
+
+        var availableMiB = availableBytes.Value / BytesPerMiB;
+        if (availableMiB < requiredMiB.Value)
+        {
+            hardFailure = true;
+            reasons.Add(new RecommendationReason(
+                "capability.storage-insufficient",
+                $"{application.Name} requires at least {requiredMiB} MiB of free storage; the system drive reports {availableMiB} MiB."));
+        }
+    }
+
+    private static void AddRecommendedCapabilityAdvisories(
+        ApplicationDefinition application,
+        MachineSnapshot machine,
+        ICollection<RecommendationReason> reasons)
+    {
+        var recommended = application.Requirements.Recommended;
+
+        if (recommended.MinRamMiB is > 0 && machine.Memory.TotalPhysicalBytes is { } totalBytes)
+        {
+            var totalMiB = totalBytes / (ulong)BytesPerMiB;
+            if (totalMiB < (ulong)recommended.MinRamMiB.Value)
+            {
+                reasons.Add(new RecommendationReason(
+                    "capability.ram-below-recommended",
+                    $"{application.Name} meets its minimum RAM requirement, but {recommended.MinRamMiB} MiB or more is recommended."));
+            }
+        }
+
+        if (recommended.MinFreeStorageMiB is > 0 && machine.SystemDrive?.AvailableBytes is >= 0 and var availableBytes)
+        {
+            var availableMiB = availableBytes / BytesPerMiB;
+            if (availableMiB < recommended.MinFreeStorageMiB.Value)
+            {
+                reasons.Add(new RecommendationReason(
+                    "capability.storage-below-recommended",
+                    $"{application.Name} meets its minimum storage requirement, but {recommended.MinFreeStorageMiB} MiB or more free space is recommended."));
+            }
+        }
+    }
+
+    private static void ResolveInstalledConflicts(
+        IList<RecommendationDecision> decisions,
+        IReadOnlyDictionary<string, ApplicationDefinition> applications,
+        IReadOnlyDictionary<string, DetectedApplicationState> software)
+    {
+        for (var index = 0; index < decisions.Count; index++)
+        {
+            var decision = decisions[index];
+            if (decision.Disposition != RecommendationDisposition.Recommended)
+            {
+                continue;
+            }
+
+            var application = applications[decision.ApplicationId];
+            var installedConflict = applications.Values
+                .Where(other => !string.Equals(other.Id, application.Id, StringComparison.OrdinalIgnoreCase))
+                .Where(other => ConflictsWith(application, other))
+                .FirstOrDefault(other =>
+                    software.TryGetValue(other.Id, out var state) &&
+                    state.State == SoftwarePresenceState.Installed);
+
+            if (installedConflict is null)
+            {
+                continue;
+            }
+
+            decisions[index] = decision with
+            {
+                Disposition = RecommendationDisposition.Conflict,
+                SelectedByDefault = false,
+                Reasons = AppendReason(
+                    decision.Reasons,
+                    new RecommendationReason(
+                        "conflict.installed-application",
+                        $"{decision.ApplicationName} conflicts with already-installed {installedConflict.Name}, so it will not be preselected."))
+            };
+        }
+    }
+
+    private static void ResolveRecommendationConflicts(
+        IList<RecommendationDecision> decisions,
+        IReadOnlyDictionary<string, ApplicationDefinition> applications)
+    {
+        var order = Enumerable.Range(0, decisions.Count)
+            .Where(index => decisions[index].Disposition == RecommendationDisposition.Recommended)
+            .OrderBy(index => LevelRank(decisions[index].Level))
+            .ThenBy(index => decisions[index].ApplicationId, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        for (var winnerPosition = 0; winnerPosition < order.Length; winnerPosition++)
+        {
+            var winnerIndex = order[winnerPosition];
+            if (decisions[winnerIndex].Disposition != RecommendationDisposition.Recommended)
+            {
+                continue;
+            }
+
+            var winner = applications[decisions[winnerIndex].ApplicationId];
+
+            for (var loserPosition = winnerPosition + 1; loserPosition < order.Length; loserPosition++)
+            {
+                var loserIndex = order[loserPosition];
+                var loserDecision = decisions[loserIndex];
+                if (loserDecision.Disposition != RecommendationDisposition.Recommended)
+                {
+                    continue;
+                }
+
+                var loser = applications[loserDecision.ApplicationId];
+                if (!ConflictsWith(winner, loser))
+                {
+                    continue;
+                }
+
+                decisions[loserIndex] = loserDecision with
+                {
+                    Disposition = RecommendationDisposition.Conflict,
+                    SelectedByDefault = false,
+                    Reasons = AppendReason(
+                        loserDecision.Reasons,
+                        new RecommendationReason(
+                            "conflict.recommendation",
+                            $"{loserDecision.ApplicationName} conflicts with the higher-priority recommendation {decisions[winnerIndex].ApplicationName}."))
+                };
+            }
+        }
+    }
+
+    private static bool ConflictsWith(
+        ApplicationDefinition first,
+        ApplicationDefinition second) =>
+        first.Conflicts.Contains(second.Id, StringComparer.OrdinalIgnoreCase) ||
+        second.Conflicts.Contains(first.Id, StringComparer.OrdinalIgnoreCase);
+
+    private static RecommendationDecision Decision(
+        ApplicationDefinition application,
+        UserProfile profile,
+        ProfileRecommendation profileRule,
+        RecommendationDisposition disposition,
+        bool selectedByDefault,
+        IReadOnlyList<RecommendationReason> reasons) =>
+        new(
+            application.Id,
+            application.Name,
+            profile,
+            profileRule.Level,
+            profileRule.ReasonKey,
+            disposition,
+            selectedByDefault,
+            reasons.ToArray());
+
+    private static RecommendationReason LifecycleReason(ApplicationDefinition application) =>
+        application.Lifecycle switch
+        {
+            ApplicationLifecycleStatus.Deprecated => new RecommendationReason(
+                "catalogue.lifecycle-deprecated",
+                $"{application.Name} is deprecated in the AgenStart catalogue and is not recommended for a new installation."),
+            ApplicationLifecycleStatus.Blocked => new RecommendationReason(
+                "catalogue.lifecycle-blocked",
+                $"{application.Name} is blocked by the AgenStart catalogue and cannot be recommended for installation."),
+            _ => throw new ArgumentOutOfRangeException(nameof(application))
+        };
+
+    private static string ProfileMessage(
+        string applicationName,
+        UserProfile profile,
+        RecommendationLevel level) =>
+        level switch
+        {
+            RecommendationLevel.Essential =>
+                $"{applicationName} is essential for the {profile} profile.",
+            RecommendationLevel.Recommended =>
+                $"{applicationName} is recommended for the {profile} profile.",
+            RecommendationLevel.Optional =>
+                $"{applicationName} is an optional suggestion for the {profile} profile.",
+            _ => throw new ArgumentOutOfRangeException(nameof(level))
+        };
+
+    private static IReadOnlyList<RecommendationReason> AppendReason(
+        IReadOnlyList<RecommendationReason> existing,
+        RecommendationReason reason) =>
+        [.. existing, reason];
+
+    private static int LevelRank(RecommendationLevel level) =>
+        level switch
+        {
+            RecommendationLevel.Essential => 0,
+            RecommendationLevel.Recommended => 1,
+            RecommendationLevel.Optional => 2,
+            _ => int.MaxValue
+        };
+
+    private static void ValidateRequirements(
+        CapabilityRequirements requirements,
+        string applicationId,
+        string label)
+    {
+        ArgumentNullException.ThrowIfNull(requirements);
+
+        if (requirements.MinRamMiB is < 0)
+        {
+            throw new InvalidOperationException(
+                $"Application {applicationId} has a negative {label} RAM requirement.");
+        }
+
+        if (requirements.MinFreeStorageMiB is < 0)
+        {
+            throw new InvalidOperationException(
+                $"Application {applicationId} has a negative {label} storage requirement.");
+        }
+    }
+
+    private static string RequireText(string value, string label)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{label} cannot be empty.");
+        }
+
+        return value.Trim();
+    }
+
+    private sealed record CompatibilityResult(
+        bool HasHardFailure,
+        bool HasUnknown,
+        IReadOnlyList<RecommendationReason> Reasons);
+}

--- a/tests/AgenStart.Recommendations.Tests/AgenStart.Recommendations.Tests.csproj
+++ b/tests/AgenStart.Recommendations.Tests/AgenStart.Recommendations.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgenStart.Core\AgenStart.Core.csproj" />
+    <ProjectReference Include="..\..\src\AgenStart.Recommendations\AgenStart.Recommendations.csproj" />
+    <ProjectReference Include="..\..\src\AgenStart.SoftwareInventory\AgenStart.SoftwareInventory.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/AgenStart.Recommendations.Tests/RecommendationEngineTests.cs
+++ b/tests/AgenStart.Recommendations.Tests/RecommendationEngineTests.cs
@@ -1,0 +1,411 @@
+using AgenStart.Core.Catalogue;
+using AgenStart.Core.Machine;
+using AgenStart.Recommendations;
+using AgenStart.SoftwareInventory;
+using Xunit;
+
+namespace AgenStart.Recommendations.Tests;
+
+public sealed class RecommendationEngineTests
+{
+    private readonly RecommendationEngine _engine = new();
+
+    [Theory]
+    [InlineData(UserProfile.Personal)]
+    [InlineData(UserProfile.Development)]
+    [InlineData(UserProfile.Business)]
+    [InlineData(UserProfile.Creation)]
+    [InlineData(UserProfile.Training)]
+    public void Build_SupportsEveryInitialProfileWithHumanReadableReason(UserProfile profile)
+    {
+        var application = Application(
+            $"{profile.ToString().ToLowerInvariant()}-tool",
+            $"{profile} Tool",
+            profile,
+            RecommendationLevel.Recommended);
+
+        var plan = _engine.Build(Request(
+            profile,
+            CapableMachine(),
+            [Missing(application.Id)],
+            [application]));
+
+        var decision = Assert.Single(plan.Decisions);
+        Assert.Equal(RecommendationDisposition.Recommended, decision.Disposition);
+        Assert.True(decision.SelectedByDefault);
+        Assert.False(string.IsNullOrWhiteSpace(decision.ProfileReasonKey));
+        Assert.Contains(
+            decision.Reasons,
+            reason => reason.Message.Contains(profile.ToString(), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Build_AlreadyInstalledApplicationIsExplicitAndNotSelected()
+    {
+        var application = Application(
+            "git",
+            "Git",
+            UserProfile.Development,
+            RecommendationLevel.Essential);
+
+        var plan = _engine.Build(Request(
+            UserProfile.Development,
+            CapableMachine(),
+            [Installed("git", "2.51.0")],
+            [application]));
+
+        var decision = Assert.Single(plan.Decisions);
+        Assert.Equal(RecommendationDisposition.AlreadyInstalled, decision.Disposition);
+        Assert.False(decision.SelectedByDefault);
+        Assert.Contains(
+            decision.Reasons,
+            reason => reason.Code == "software.already-installed" &&
+                      reason.Message.Contains("2.51.0", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Build_UnknownInstalledStateDoesNotCreateDuplicateInstallProposal()
+    {
+        var application = Application(
+            "visual-studio-code",
+            "Visual Studio Code",
+            UserProfile.Development,
+            RecommendationLevel.Recommended);
+
+        var plan = _engine.Build(Request(
+            UserProfile.Development,
+            CapableMachine(),
+            [Unknown("visual-studio-code")],
+            [application]));
+
+        var decision = Assert.Single(plan.Decisions);
+        Assert.Equal(RecommendationDisposition.InventoryUnknown, decision.Disposition);
+        Assert.False(decision.SelectedByDefault);
+    }
+
+    [Fact]
+    public void Build_InsufficientMinimumRamMakesRecommendationIncompatible()
+    {
+        var application = Application(
+            "docker-desktop",
+            "Docker Desktop",
+            UserProfile.Development,
+            RecommendationLevel.Optional,
+            minimum: Requirements(minRamMiB: 8192, minStorageMiB: 8192));
+
+        var plan = _engine.Build(Request(
+            UserProfile.Development,
+            CapableMachine(totalRamMiB: 4096, freeStorageMiB: 32_000),
+            [Missing(application.Id)],
+            [application]));
+
+        var decision = Assert.Single(plan.Decisions);
+        Assert.Equal(RecommendationDisposition.Incompatible, decision.Disposition);
+        Assert.Contains(decision.Reasons, reason => reason.Code == "capability.ram-insufficient");
+    }
+
+    [Fact]
+    public void Build_UnknownRequiredCapabilityIsNotAssumedCompatible()
+    {
+        var application = Application(
+            "docker-desktop",
+            "Docker Desktop",
+            UserProfile.Development,
+            RecommendationLevel.Optional,
+            minimum: Requirements(minRamMiB: 8192, minStorageMiB: 8192));
+
+        var plan = _engine.Build(Request(
+            UserProfile.Development,
+            CapableMachine(totalRamMiB: null, freeStorageMiB: 32_000),
+            [Missing(application.Id)],
+            [application]));
+
+        var decision = Assert.Single(plan.Decisions);
+        Assert.Equal(RecommendationDisposition.CompatibilityUnknown, decision.Disposition);
+        Assert.Contains(decision.Reasons, reason => reason.Code == "capability.ram-unknown");
+    }
+
+    [Fact]
+    public void Build_GpuRequirementIsEnforced()
+    {
+        var application = Application(
+            "obs-studio",
+            "OBS Studio",
+            UserProfile.Creation,
+            RecommendationLevel.Recommended,
+            minimum: Requirements(gpuRequired: true));
+
+        var plan = _engine.Build(Request(
+            UserProfile.Creation,
+            CapableMachine(gpu: GpuCapabilityState.Unavailable),
+            [Missing(application.Id)],
+            [application]));
+
+        var decision = Assert.Single(plan.Decisions);
+        Assert.Equal(RecommendationDisposition.Incompatible, decision.Disposition);
+        Assert.Contains(decision.Reasons, reason => reason.Code == "capability.gpu-required");
+    }
+
+    [Fact]
+    public void Build_OptionalRecommendationIsVisibleButNotPreselected()
+    {
+        var application = Application(
+            "firefox",
+            "Mozilla Firefox",
+            UserProfile.Development,
+            RecommendationLevel.Optional);
+
+        var decision = Assert.Single(_engine.Build(Request(
+            UserProfile.Development,
+            CapableMachine(),
+            [Missing(application.Id)],
+            [application])).Decisions);
+
+        Assert.Equal(RecommendationDisposition.Recommended, decision.Disposition);
+        Assert.False(decision.SelectedByDefault);
+    }
+
+    [Fact]
+    public void Build_InstalledConflictBlocksCandidate()
+    {
+        var candidate = Application(
+            "candidate",
+            "Candidate",
+            UserProfile.Business,
+            RecommendationLevel.Recommended,
+            conflicts: ["existing"]);
+        var existing = Application(
+            "existing",
+            "Existing Tool",
+            UserProfile.Personal,
+            RecommendationLevel.Optional);
+
+        var plan = _engine.Build(Request(
+            UserProfile.Business,
+            CapableMachine(),
+            [Missing(candidate.Id), Installed(existing.Id, "1.0")],
+            [candidate, existing]));
+
+        var decision = Assert.Single(plan.Decisions);
+        Assert.Equal(RecommendationDisposition.Conflict, decision.Disposition);
+        Assert.False(decision.SelectedByDefault);
+        Assert.Contains(decision.Reasons, reason => reason.Code == "conflict.installed-application");
+    }
+
+    [Fact]
+    public void Build_ConflictingRecommendationsResolveDeterministicallyByLevel()
+    {
+        var essential = Application(
+            "essential-tool",
+            "Essential Tool",
+            UserProfile.Development,
+            RecommendationLevel.Essential,
+            conflicts: ["optional-tool"]);
+        var optional = Application(
+            "optional-tool",
+            "Optional Tool",
+            UserProfile.Development,
+            RecommendationLevel.Optional);
+
+        var plan = _engine.Build(Request(
+            UserProfile.Development,
+            CapableMachine(),
+            [Missing(essential.Id), Missing(optional.Id)],
+            [optional, essential]));
+
+        var winner = Assert.Single(plan.Decisions, decision => decision.ApplicationId == essential.Id);
+        var loser = Assert.Single(plan.Decisions, decision => decision.ApplicationId == optional.Id);
+
+        Assert.Equal(RecommendationDisposition.Recommended, winner.Disposition);
+        Assert.True(winner.SelectedByDefault);
+        Assert.Equal(RecommendationDisposition.Conflict, loser.Disposition);
+        Assert.False(loser.SelectedByDefault);
+        Assert.Contains(loser.Reasons, reason => reason.Code == "conflict.recommendation");
+    }
+
+    [Fact]
+    public void Build_BelowRecommendedCapabilityAddsAdvisoryWithoutBlocking()
+    {
+        var application = Application(
+            "editor",
+            "Editor",
+            UserProfile.Development,
+            RecommendationLevel.Recommended,
+            minimum: Requirements(minRamMiB: 2048),
+            recommended: Requirements(minRamMiB: 8192));
+
+        var decision = Assert.Single(_engine.Build(Request(
+            UserProfile.Development,
+            CapableMachine(totalRamMiB: 4096),
+            [Missing(application.Id)],
+            [application])).Decisions);
+
+        Assert.Equal(RecommendationDisposition.Recommended, decision.Disposition);
+        Assert.True(decision.SelectedByDefault);
+        Assert.Contains(decision.Reasons, reason => reason.Code == "capability.ram-below-recommended");
+    }
+
+    [Fact]
+    public void Build_DuplicateCanonicalApplicationIdFailsClosed()
+    {
+        var first = Application("same", "One", UserProfile.Personal, RecommendationLevel.Recommended);
+        var second = Application("same", "Two", UserProfile.Personal, RecommendationLevel.Recommended);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            _engine.Build(Request(
+                UserProfile.Personal,
+                CapableMachine(),
+                [Missing("same")],
+                [first, second])));
+    }
+
+    [Fact]
+    public void Build_DuplicateProfileRuleFailsClosed()
+    {
+        var application = Application(
+            "duplicate-rules",
+            "Duplicate Rules",
+            UserProfile.Personal,
+            RecommendationLevel.Recommended) with
+        {
+            Recommendations =
+            [
+                new ProfileRecommendation(UserProfile.Personal, RecommendationLevel.Recommended, "personal.first"),
+                new ProfileRecommendation(UserProfile.Personal, RecommendationLevel.Optional, "personal.second")
+            ]
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            _engine.Build(Request(
+                UserProfile.Personal,
+                CapableMachine(),
+                [Missing(application.Id)],
+                [application])));
+    }
+
+    [Fact]
+    public void Build_ApplicationOutsideSelectedProfileIsNotReturned()
+    {
+        var application = Application(
+            "git",
+            "Git",
+            UserProfile.Development,
+            RecommendationLevel.Essential);
+
+        var plan = _engine.Build(Request(
+            UserProfile.Business,
+            CapableMachine(),
+            [Missing(application.Id)],
+            [application]));
+
+        Assert.Empty(plan.Decisions);
+    }
+
+    private static RecommendationRequest Request(
+        UserProfile profile,
+        MachineSnapshot machine,
+        IReadOnlyList<DetectedApplicationState> software,
+        IReadOnlyList<ApplicationDefinition> applications) =>
+        new(
+            profile,
+            machine,
+            new SoftwareDetectionResult(software, 0),
+            applications);
+
+    private static ApplicationDefinition Application(
+        string id,
+        string name,
+        UserProfile profile,
+        RecommendationLevel level,
+        CapabilityRequirements? minimum = null,
+        CapabilityRequirements? recommended = null,
+        IReadOnlyList<string>? conflicts = null) =>
+        new(
+            id,
+            name,
+            ApplicationLifecycleStatus.Active,
+            [new ProfileRecommendation(profile, level, $"{profile.ToString().ToLowerInvariant()}.fixture")],
+            new ApplicationRequirements(
+                minimum ?? Requirements(),
+                recommended ?? Requirements()),
+            [new PlatformSupportRule(
+                PlatformKind.Windows,
+                PlatformSupportStatus.Supported,
+                [MachineArchitecture.X64, MachineArchitecture.Arm64])],
+            [],
+            conflicts ?? []);
+
+    private static CapabilityRequirements Requirements(
+        long? minRamMiB = 512,
+        long? minStorageMiB = 256,
+        bool gpuRequired = false) =>
+        new(
+            minRamMiB,
+            minStorageMiB,
+            gpuRequired,
+            [MachineArchitecture.X64, MachineArchitecture.Arm64]);
+
+    private static MachineSnapshot CapableMachine(
+        long? totalRamMiB = 16_384,
+        long? freeStorageMiB = 64_000,
+        GpuCapabilityState gpu = GpuCapabilityState.Available) =>
+        new(
+            new PlatformSnapshot(
+                PlatformKind.Windows,
+                "Windows 11 Pro",
+                "24H2",
+                new Version(10, 0),
+                "26100",
+                null,
+                MachineArchitecture.X64,
+                MachineArchitecture.X64),
+            new CpuSnapshot("Fixture CPU", MachineArchitecture.X64, 8),
+            new MemorySnapshot(
+                totalRamMiB is null ? null : MiBToBytesUnsigned(totalRamMiB.Value),
+                null),
+            gpu == GpuCapabilityState.Available
+                ? [new GpuSnapshot("Fixture GPU", "Fixture Vendor")]
+                : [],
+            [new StorageSnapshot(
+                "C:\\",
+                StorageKind.Fixed,
+                512L * 1024 * 1024 * 1024,
+                freeStorageMiB is null ? null : MiBToBytes(freeStorageMiB.Value),
+                true)],
+            new PackageManagerSnapshot(
+                PackageManagerKind.WinGet,
+                CapabilityState.Available,
+                new Version(1, 12)),
+            new CapabilitySnapshot(gpu),
+            [],
+            DateTimeOffset.UnixEpoch);
+
+    private static DetectedApplicationState Missing(string applicationId) =>
+        new(
+            applicationId,
+            SoftwarePresenceState.Missing,
+            null,
+            [],
+            []);
+
+    private static DetectedApplicationState Unknown(string applicationId) =>
+        new(
+            applicationId,
+            SoftwarePresenceState.Unknown,
+            null,
+            [],
+            [new SoftwareStateDiagnostic("fixture.unknown", "Fixture inventory is incomplete.")]);
+
+    private static DetectedApplicationState Installed(string applicationId, string version) =>
+        new(
+            applicationId,
+            SoftwarePresenceState.Installed,
+            version,
+            [],
+            []);
+
+    private static long MiBToBytes(long value) => value * 1024L * 1024L;
+
+    private static ulong MiBToBytesUnsigned(long value) =>
+        checked((ulong)value * 1024UL * 1024UL);
+}


### PR DESCRIPTION
## Summary

Implements AgenStart's deterministic, explainable recommendation engine.

### Core domain
- initializes `AgenStart.Core` without UI or platform dependencies
- adds the normalized cross-platform `MachineSnapshot` family from the machine-inventory architecture
- adds catalogue recommendation contracts for profiles, levels, lifecycle, platform support and capability requirements

### Recommendation engine
- supports Personal, Development, Business, Creation and Training profiles
- consumes normalized machine and installed-software state
- preserves catalogue `reasonKey` and emits human-readable explanations
- enforces platform, architecture, RAM, storage and GPU minimum constraints
- does not treat unknown capability values as compatible
- treats unknown software presence conservatively to avoid duplicate install proposals
- handles already-installed applications explicitly
- keeps optional recommendations visible but not preselected
- adds advisory explanations when minimum requirements pass but recommended capabilities are not met

### Deterministic conflicts
- blocks candidates conflicting with already-installed software
- resolves recommendation conflicts by level: Essential > Recommended > Optional
- uses canonical application ID as deterministic tie-breaker at equal level
- validates duplicate IDs, duplicate profile rules and invalid graph references fail-closed

### Boundary
- no installer/package-manager execution
- no Registry/WinGet access
- dependency references are validated here; dependency expansion/order remains installation orchestration work for #7
- user validation remains the final authority before execution

### Verification
- new platform-independent `.NET 10` recommendation test gate on Ubuntu
- representative tests for all five profiles, installed/unknown state, hardware constraints, conflicts, advisories and invalid catalogue input
- adds `docs/architecture/recommendation-engine.md`

Closes #6