### PR TITLE
feat: implement installation queue and execution orchestrator

### DIFF
--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -1,0 +1,44 @@
+name: Installation tests
+
+on:
+  push:
+    paths:
+      - "src/AgenStart.Application/**"
+      - "src/AgenStart.PackageManagement/**"
+      - "src/AgenStart.SoftwareInventory/**"
+      - "tests/AgenStart.Application.Tests/**"
+      - "docs/architecture/installation-orchestrator.md"
+      - ".github/workflows/installation-tests.yml"
+      - "global.json"
+  pull_request:
+    paths:
+      - "src/AgenStart.Application/**"
+      - "src/AgenStart.PackageManagement/**"
+      - "src/AgenStart.SoftwareInventory/**"
+      - "tests/AgenStart.Application.Tests/**"
+      - "docs/architecture/installation-orchestrator.md"
+      - ".github/workflows/installation-tests.yml"
+      - "global.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore
+        run: dotnet restore tests/AgenStart.Application.Tests/AgenStart.Application.Tests.csproj
+
+      - name: Test
+        run: dotnet test tests/AgenStart.Application.Tests/AgenStart.Application.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/docs/architecture/installation-orchestrator.md
+++ b/docs/architecture/installation-orchestrator.md
@@ -1,0 +1,186 @@
+# Installation queue and execution orchestrator
+
+## Purpose
+
+Issue #7 introduces the application-layer execution boundary that turns a user-approved software selection into a controlled installation session.
+
+The orchestrator does not execute shell commands and does not know WinGet arguments. It consumes only the typed `IPackageProvider` contract introduced by #4 and the normalized installed-software state introduced by #5.
+
+```text
+User-approved selection
+        |
+        v
+InstallationOrchestrator
+        |
+        +--> IInstallationVerifier --> normalized software inventory
+        |
+        `--> IPackageProvider -------> WinGetProvider (Windows V1)
+```
+
+The UI remains outside this boundary. It observes session state and progress events and may request cancellation or an explicit retry.
+
+## Approval boundary
+
+Only selections with `Approved = true` enter the executable queue.
+
+Non-approved selections are retained in the session report as `Skipped` with diagnostic code `selection.not-approved`. This makes the final report complete while preserving the security/product rule that AgenStart never installs a recommendation merely because it was suggested.
+
+## Queue model
+
+V1 executes sequentially.
+
+Item states:
+
+```text
+Queued
+Running
+Succeeded
+Failed
+Skipped
+Cancelled
+```
+
+Session states:
+
+```text
+Ready
+Running
+Cancelling
+Completed
+Cancelled
+```
+
+The session object is the in-memory source of truth for the active run. It preserves sequence, attempt count, provider result, verification result, retry eligibility, reboot requirement and timestamps.
+
+Durable recovery across application restarts is deferred. "Persisted for the active session" in V1 means state is retained consistently in the active `InstallationSession`, not written to a long-lived machine database.
+
+## Execution sequence
+
+For each approved queued item the orchestrator performs:
+
+1. mark item `Running` and increment attempt count;
+2. refresh installed-state verification before provider execution;
+3. if already installed, mark `Succeeded` with `AlreadyInstalled` and skip provider execution;
+4. locate the registered provider by exact provider ID;
+5. check provider availability;
+6. resolve the exact trusted package reference;
+7. call `IPackageProvider.InstallAsync` with the typed user-approved request;
+8. normalize cancellation/failure results;
+9. refresh installed-state verification after a verifiable provider completion;
+10. derive the final queue item state and publish progress.
+
+No fuzzy package lookup, source fallback, arbitrary command or shell execution is introduced by the orchestrator.
+
+## Post-install verification
+
+Provider exit status alone is not enough to claim installation success.
+
+`SoftwareInventoryInstallationVerifier` refreshes `IInstalledSoftwareInventoryProvider` and resolves the application through `SoftwareStateResolver`.
+
+Mapping:
+
+```text
+Installed -> Verified
+Missing   -> NotInstalled
+Unknown   -> Unknown
+```
+
+A provider result of `Succeeded`, `AlreadyInstalled` or `RebootRequired` becomes final `Succeeded` only when installed state is verified.
+
+If the provider completed but inventory proves the application is still missing, the item becomes `Failed` and may be retried.
+
+If inventory is incomplete/ambiguous after a provider completion, the item becomes `Failed` with retry disabled. AgenStart deliberately avoids repeating an installation that may already have succeeded.
+
+## Retry policy
+
+The provider layer performs no implicit retry. Retry policy belongs here.
+
+Initial retryable provider states are limited to conditions that may reasonably change without changing package identity:
+
+```text
+NetworkFailure
+SourceUnavailable
+TimedOut
+ProviderUnavailable
+Failed
+```
+
+Retryable resolution states follow the same conservative principle.
+
+`RequiresElevation`, agreement failures, policy blocks, integrity failures, ambiguous packages and unsupported installers are not automatically retryable.
+
+A retry is always explicit. Before invoking the provider again, the orchestrator re-runs installed-state verification. If the package is now detected, the retry finishes as `Succeeded / AlreadyInstalled` without a second provider installation call.
+
+This protects against duplicate side effects when the previous installer completed but its original operation result or immediate verification was inconclusive.
+
+## Cancellation semantics
+
+Cancellation is cooperative at the application layer and is propagated to provider operations through a linked `CancellationToken`.
+
+When cancellation is requested:
+
+- the active provider receives cancellation;
+- the current item becomes `Cancelled` when provider execution/resolution reports cancellation or throws due to the linked token;
+- all not-yet-started `Queued` items become `Cancelled`;
+- already `Succeeded`, `Failed` or `Skipped` items remain unchanged;
+- the session ends as `Cancelled`.
+
+A cancelled session cannot be resumed or retried in V1. The user creates a new session from a fresh approved selection instead.
+
+## Progress and observability
+
+`InstallationSession.ProgressChanged` publishes structured `InstallationProgressEvent` values containing:
+
+- session ID and state;
+- item snapshot when applicable;
+- stable diagnostic/event code;
+- human-readable message;
+- UTC timestamp.
+
+These events are suitable for the future Avalonia UI and for privacy-minimal local diagnostics. They are not telemetry by themselves.
+
+## Final report
+
+`InstallationReport` includes every original selection, including skipped items, with:
+
+- deterministic sequence;
+- application/package identity;
+- final state;
+- attempt count;
+- last normalized provider status;
+- diagnostic code/message;
+- installed version when verified;
+- retry eligibility;
+- reboot requirement;
+- start/completion timestamps.
+
+Summary counters expose succeeded, failed, skipped and cancelled totals.
+
+## Security properties
+
+The orchestrator preserves ADR-0002 and the #4 provider boundary:
+
+- no `cmd.exe` or PowerShell command construction;
+- no arbitrary provider arguments;
+- no fuzzy execution-time package selection;
+- no automatic source fallback;
+- no automatic elevation broker;
+- no implicit retry;
+- no installation of unapproved recommendations;
+- no success claim without post-install verification.
+
+## Verification gate
+
+`Installation tests` runs on every relevant `push` and `pull_request`, plus manual dispatch.
+
+The test suite covers:
+
+- approved-only queue execution;
+- deterministic sequential order;
+- skipped non-approved items;
+- normalized retryable provider failure;
+- retry without duplicate installation;
+- session cancellation and cancellation of remaining queued items;
+- post-install unknown state not being claimed as success;
+- reboot-required success after verification;
+- real `SoftwareInventoryInstallationVerifier` mapping for installed and incomplete inventory states.

--- a/src/AgenStart.Application/AgenStart.Application.csproj
+++ b/src/AgenStart.Application/AgenStart.Application.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgenStart.PackageManagement\AgenStart.PackageManagement.csproj" />
+    <ProjectReference Include="..\AgenStart.SoftwareInventory\AgenStart.SoftwareInventory.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AgenStart.Application/Installation/InstallationContracts.cs
+++ b/src/AgenStart.Application/Installation/InstallationContracts.cs
@@ -1,0 +1,87 @@
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Application.Installation;
+
+public enum InstallationQueueItemState
+{
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Skipped,
+    Cancelled
+}
+
+public enum InstallationSessionState
+{
+    Ready,
+    Running,
+    Cancelling,
+    Completed,
+    Cancelled
+}
+
+public enum InstallationVerificationStatus
+{
+    Verified,
+    NotInstalled,
+    Unknown
+}
+
+public sealed record InstallationSelection(
+    string ApplicationId,
+    ProviderPackageReference Package,
+    bool Approved,
+    bool Silent = true,
+    bool AcceptPackageAgreements = false,
+    bool AcceptSourceAgreements = false);
+
+public sealed record InstallationVerificationResult(
+    InstallationVerificationStatus Status,
+    string? InstalledVersion = null,
+    string? DiagnosticCode = null,
+    string? Message = null);
+
+public interface IInstallationVerifier
+{
+    Task<InstallationVerificationResult> VerifyAsync(
+        string applicationId,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record InstallationItemSnapshot(
+    int Sequence,
+    string ApplicationId,
+    ProviderPackageReference Package,
+    InstallationQueueItemState State,
+    int AttemptCount,
+    PackageOperationStatus? LastOperationStatus,
+    string? DiagnosticCode,
+    string? Message,
+    string? InstalledVersion,
+    bool CanRetry,
+    bool RequiresReboot,
+    DateTimeOffset? StartedAtUtc,
+    DateTimeOffset? CompletedAtUtc);
+
+public sealed record InstallationProgressEvent(
+    Guid SessionId,
+    InstallationSessionState SessionState,
+    InstallationItemSnapshot? Item,
+    string Code,
+    string Message,
+    DateTimeOffset OccurredAtUtc);
+
+public sealed record InstallationReport(
+    Guid SessionId,
+    InstallationSessionState State,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? StartedAtUtc,
+    DateTimeOffset? CompletedAtUtc,
+    IReadOnlyList<InstallationItemSnapshot> Items)
+{
+    public int SucceededCount => Items.Count(item => item.State == InstallationQueueItemState.Succeeded);
+    public int FailedCount => Items.Count(item => item.State == InstallationQueueItemState.Failed);
+    public int SkippedCount => Items.Count(item => item.State == InstallationQueueItemState.Skipped);
+    public int CancelledCount => Items.Count(item => item.State == InstallationQueueItemState.Cancelled);
+}

--- a/src/AgenStart.Application/Installation/InstallationOrchestrator.cs
+++ b/src/AgenStart.Application/Installation/InstallationOrchestrator.cs
@@ -1,0 +1,306 @@
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Application.Installation;
+
+public sealed class InstallationOrchestrator
+{
+    private readonly IReadOnlyDictionary<string, IPackageProvider> _providers;
+    private readonly IInstallationVerifier _verifier;
+    private readonly TimeProvider _timeProvider;
+
+    public InstallationOrchestrator(
+        IEnumerable<IPackageProvider> providers,
+        IInstallationVerifier verifier,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+        _verifier = verifier ?? throw new ArgumentNullException(nameof(verifier));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+
+        var providerMap = new Dictionary<string, IPackageProvider>(StringComparer.OrdinalIgnoreCase);
+        foreach (var provider in providers)
+        {
+            ArgumentNullException.ThrowIfNull(provider);
+            if (string.IsNullOrWhiteSpace(provider.ProviderId))
+            {
+                throw new ArgumentException("Package providers must expose a provider id.", nameof(providers));
+            }
+
+            if (!providerMap.TryAdd(provider.ProviderId.Trim(), provider))
+            {
+                throw new ArgumentException(
+                    $"Package provider {provider.ProviderId} was registered more than once.",
+                    nameof(providers));
+            }
+        }
+
+        _providers = providerMap;
+    }
+
+    public InstallationSession CreateSession(IReadOnlyList<InstallationSelection> selections) =>
+        new(selections, _timeProvider);
+
+    public async Task<InstallationReport> RunAsync(
+        InstallationSession session,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        session.BeginRun();
+
+        using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            session.CancellationToken,
+            cancellationToken);
+        var token = linkedCancellation.Token;
+        var cancelled = false;
+
+        foreach (var item in session.MutableItems)
+        {
+            if (item.State != InstallationQueueItemState.Queued)
+            {
+                continue;
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                cancelled = true;
+                break;
+            }
+
+            cancelled = await ExecuteItemAsync(session, item, token).ConfigureAwait(false);
+            if (cancelled)
+            {
+                break;
+            }
+        }
+
+        if (cancelled || token.IsCancellationRequested)
+        {
+            session.MarkQueuedItemsCancelled(
+                "installation.cancelled-before-start",
+                "The item was cancelled before execution started.");
+            session.CompleteRun(cancelled: true);
+        }
+        else
+        {
+            session.CompleteRun(cancelled: false);
+        }
+
+        return session.CreateReport();
+    }
+
+    public async Task<InstallationReport> RetryAsync(
+        InstallationSession session,
+        string applicationId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        if (string.IsNullOrWhiteSpace(applicationId))
+        {
+            throw new ArgumentException("An application id is required.", nameof(applicationId));
+        }
+
+        session.PrepareRetry(applicationId.Trim());
+        return await RunAsync(session, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> ExecuteItemAsync(
+        InstallationSession session,
+        InstallationSession.InstallationQueueItem item,
+        CancellationToken cancellationToken)
+    {
+        session.MarkRunning(item);
+
+        try
+        {
+            var preVerification = await _verifier
+                .VerifyAsync(item.Selection.ApplicationId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (preVerification.Status == InstallationVerificationStatus.Verified)
+            {
+                session.MarkSucceeded(
+                    item,
+                    preVerification.InstalledVersion,
+                    PackageOperationStatus.AlreadyInstalled,
+                    requiresReboot: false,
+                    $"{item.Selection.ApplicationId} is already installed; provider execution was skipped.");
+                return false;
+            }
+
+            if (!_providers.TryGetValue(item.Selection.Package.ProviderId, out var provider))
+            {
+                session.MarkFailed(
+                    item,
+                    "installation.provider-not-registered",
+                    $"Provider {item.Selection.Package.ProviderId} is not registered for this session.",
+                    canRetry: false,
+                    PackageOperationStatus.ProviderUnavailable);
+                return false;
+            }
+
+            var availability = await provider
+                .CheckAvailabilityAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!availability.IsAvailable)
+            {
+                session.MarkFailed(
+                    item,
+                    availability.DiagnosticCode ?? "installation.provider-unavailable",
+                    availability.Message ?? $"Provider {provider.ProviderId} is unavailable.",
+                    CanRetryAvailability(availability.Status),
+                    PackageOperationStatus.ProviderUnavailable);
+                return false;
+            }
+
+            var resolution = await provider
+                .ResolveAsync(item.Selection.Package, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!resolution.IsResolved)
+            {
+                if (resolution.Status == PackageResolutionStatus.Cancelled)
+                {
+                    session.MarkCancelled(
+                        item,
+                        resolution.DiagnosticCode ?? "installation.resolution-cancelled",
+                        resolution.Message ?? "Package resolution was cancelled.",
+                        PackageOperationStatus.Cancelled);
+                    return true;
+                }
+
+                session.MarkFailed(
+                    item,
+                    resolution.DiagnosticCode ?? "installation.package-resolution-failed",
+                    resolution.Message ?? $"Package {item.Selection.Package.PackageId} could not be resolved.",
+                    CanRetryResolution(resolution.Status),
+                    MapResolutionStatus(resolution.Status));
+                return false;
+            }
+
+            var operation = await provider
+                .InstallAsync(
+                    new PackageInstallRequest(
+                        item.Selection.ApplicationId,
+                        item.Selection.Package,
+                        item.Selection.Silent,
+                        item.Selection.AcceptPackageAgreements,
+                        item.Selection.AcceptSourceAgreements),
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (operation.Status is PackageOperationStatus.Cancelled or PackageOperationStatus.CancelledByUser)
+            {
+                session.MarkCancelled(
+                    item,
+                    operation.DiagnosticCode ?? "installation.cancelled",
+                    operation.Message ?? "Package installation was cancelled.",
+                    operation.Status);
+                return true;
+            }
+
+            if (!IsVerifiableCompletion(operation.Status))
+            {
+                session.MarkFailed(
+                    item,
+                    operation.DiagnosticCode ?? "installation.provider-failed",
+                    operation.Message ?? $"Provider installation failed with status {operation.Status}.",
+                    CanRetryOperation(operation.Status),
+                    operation.Status);
+                return false;
+            }
+
+            var verification = await _verifier
+                .VerifyAsync(item.Selection.ApplicationId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (verification.Status == InstallationVerificationStatus.Verified)
+            {
+                session.MarkSucceeded(
+                    item,
+                    verification.InstalledVersion,
+                    operation.Status,
+                    operation.Status == PackageOperationStatus.RebootRequired,
+                    verification.Message);
+                return false;
+            }
+
+            if (verification.Status == InstallationVerificationStatus.NotInstalled)
+            {
+                session.MarkFailed(
+                    item,
+                    verification.DiagnosticCode ?? "installation.verification-not-installed",
+                    verification.Message ?? "The provider completed, but the application was not detected after installation.",
+                    canRetry: true,
+                    operation.Status);
+                return false;
+            }
+
+            session.MarkFailed(
+                item,
+                verification.DiagnosticCode ?? "installation.verification-unknown",
+                verification.Message ?? "Installation completed, but installed state could not be verified safely.",
+                canRetry: false,
+                operation.Status);
+            return false;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            session.MarkCancelled(
+                item,
+                "installation.cancelled",
+                "Package installation was cancelled.",
+                PackageOperationStatus.Cancelled);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            session.MarkFailed(
+                item,
+                "installation.unhandled-provider-error",
+                $"The installation operation failed unexpectedly: {exception.GetType().Name}.",
+                canRetry: false,
+                PackageOperationStatus.Failed);
+            return false;
+        }
+    }
+
+    private static bool IsVerifiableCompletion(PackageOperationStatus status) =>
+        status is PackageOperationStatus.Succeeded
+            or PackageOperationStatus.AlreadyInstalled
+            or PackageOperationStatus.RebootRequired;
+
+    private static bool CanRetryAvailability(PackageProviderAvailabilityStatus status) =>
+        status is PackageProviderAvailabilityStatus.NotInstalled
+            or PackageProviderAvailabilityStatus.Unhealthy;
+
+    private static bool CanRetryResolution(PackageResolutionStatus status) =>
+        status is PackageResolutionStatus.SourceUnavailable
+            or PackageResolutionStatus.TimedOut
+            or PackageResolutionStatus.ProviderUnavailable
+            or PackageResolutionStatus.Failed;
+
+    private static bool CanRetryOperation(PackageOperationStatus status) =>
+        status is PackageOperationStatus.NetworkFailure
+            or PackageOperationStatus.SourceUnavailable
+            or PackageOperationStatus.TimedOut
+            or PackageOperationStatus.ProviderUnavailable
+            or PackageOperationStatus.Failed;
+
+    private static PackageOperationStatus? MapResolutionStatus(PackageResolutionStatus status) =>
+        status switch
+        {
+            PackageResolutionStatus.NotFound => PackageOperationStatus.NotFound,
+            PackageResolutionStatus.Ambiguous => PackageOperationStatus.Ambiguous,
+            PackageResolutionStatus.NoApplicableInstaller => PackageOperationStatus.NoApplicableInstaller,
+            PackageResolutionStatus.SourceUnavailable => PackageOperationStatus.SourceUnavailable,
+            PackageResolutionStatus.AgreementRequired => PackageOperationStatus.AgreementRequired,
+            PackageResolutionStatus.BlockedByPolicy => PackageOperationStatus.BlockedByPolicy,
+            PackageResolutionStatus.IntegrityFailure => PackageOperationStatus.IntegrityFailure,
+            PackageResolutionStatus.Cancelled => PackageOperationStatus.Cancelled,
+            PackageResolutionStatus.TimedOut => PackageOperationStatus.TimedOut,
+            PackageResolutionStatus.ProviderUnavailable => PackageOperationStatus.ProviderUnavailable,
+            PackageResolutionStatus.Failed => PackageOperationStatus.Failed,
+            _ => null
+        };
+}

--- a/src/AgenStart.Application/Installation/InstallationSession.cs
+++ b/src/AgenStart.Application/Installation/InstallationSession.cs
@@ -1,0 +1,282 @@
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Application.Installation;
+
+public sealed class InstallationSession : IDisposable
+{
+    private readonly List<InstallationQueueItem> _items;
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly TimeProvider _timeProvider;
+    private bool _disposed;
+
+    internal InstallationSession(
+        IReadOnlyList<InstallationSelection> selections,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(selections);
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+
+        SessionId = Guid.NewGuid();
+        CreatedAtUtc = _timeProvider.GetUtcNow();
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        _items = new List<InstallationQueueItem>(selections.Count);
+
+        for (var index = 0; index < selections.Count; index++)
+        {
+            var selection = selections[index] ?? throw new ArgumentException(
+                "Installation selections cannot contain null entries.",
+                nameof(selections));
+
+            if (string.IsNullOrWhiteSpace(selection.ApplicationId))
+            {
+                throw new ArgumentException(
+                    "Installation selections require a canonical application id.",
+                    nameof(selections));
+            }
+
+            ArgumentNullException.ThrowIfNull(selection.Package);
+
+            var applicationId = selection.ApplicationId.Trim();
+            if (!seen.Add(applicationId))
+            {
+                throw new InvalidOperationException(
+                    $"Application {applicationId} appears more than once in the installation selection.");
+            }
+
+            _items.Add(new InstallationQueueItem(
+                index + 1,
+                selection with { ApplicationId = applicationId },
+                selection.Approved
+                    ? InstallationQueueItemState.Queued
+                    : InstallationQueueItemState.Skipped,
+                selection.Approved ? null : "selection.not-approved",
+                selection.Approved
+                    ? null
+                    : $"{applicationId} was not approved by the user and will not be installed."));
+        }
+    }
+
+    public Guid SessionId { get; }
+    public DateTimeOffset CreatedAtUtc { get; }
+    public DateTimeOffset? StartedAtUtc { get; private set; }
+    public DateTimeOffset? CompletedAtUtc { get; private set; }
+    public InstallationSessionState State { get; private set; } = InstallationSessionState.Ready;
+
+    public IReadOnlyList<InstallationItemSnapshot> Items =>
+        _items.Select(static item => item.Snapshot()).ToArray();
+
+    public event EventHandler<InstallationProgressEvent>? ProgressChanged;
+
+    public void Cancel()
+    {
+        ThrowIfDisposed();
+
+        if (State is InstallationSessionState.Completed or InstallationSessionState.Cancelled)
+        {
+            return;
+        }
+
+        _cancellation.Cancel();
+        if (State == InstallationSessionState.Running)
+        {
+            State = InstallationSessionState.Cancelling;
+            Publish(
+                null,
+                "session.cancellation-requested",
+                "Installation session cancellation was requested.");
+        }
+    }
+
+    public InstallationReport CreateReport()
+    {
+        ThrowIfDisposed();
+        return new InstallationReport(
+            SessionId,
+            State,
+            CreatedAtUtc,
+            StartedAtUtc,
+            CompletedAtUtc,
+            Items);
+    }
+
+    internal CancellationToken CancellationToken => _cancellation.Token;
+    internal IReadOnlyList<InstallationQueueItem> MutableItems => _items;
+
+    internal void BeginRun()
+    {
+        ThrowIfDisposed();
+
+        if (State is InstallationSessionState.Running or InstallationSessionState.Cancelling)
+        {
+            throw new InvalidOperationException("The installation session is already running.");
+        }
+
+        if (State == InstallationSessionState.Cancelled)
+        {
+            throw new InvalidOperationException("A cancelled installation session cannot be executed again.");
+        }
+
+        State = InstallationSessionState.Running;
+        StartedAtUtc ??= _timeProvider.GetUtcNow();
+        CompletedAtUtc = null;
+        Publish(null, "session.started", "Installation session started.");
+    }
+
+    internal void CompleteRun(bool cancelled)
+    {
+        State = cancelled
+            ? InstallationSessionState.Cancelled
+            : InstallationSessionState.Completed;
+        CompletedAtUtc = _timeProvider.GetUtcNow();
+        Publish(
+            null,
+            cancelled ? "session.cancelled" : "session.completed",
+            cancelled
+                ? "Installation session was cancelled."
+                : "Installation session completed.");
+    }
+
+    internal void MarkQueuedItemsCancelled(string code, string message)
+    {
+        foreach (var item in _items.Where(static item => item.State == InstallationQueueItemState.Queued))
+        {
+            item.State = InstallationQueueItemState.Cancelled;
+            item.CanRetry = false;
+            item.DiagnosticCode = code;
+            item.Message = message;
+            item.CompletedAtUtc = _timeProvider.GetUtcNow();
+            Publish(item, code, message);
+        }
+    }
+
+    internal void MarkRunning(InstallationQueueItem item)
+    {
+        item.State = InstallationQueueItemState.Running;
+        item.AttemptCount++;
+        item.StartedAtUtc = _timeProvider.GetUtcNow();
+        item.CompletedAtUtc = null;
+        item.DiagnosticCode = null;
+        item.Message = null;
+        item.CanRetry = false;
+        Publish(item, "item.running", $"Installing {item.Selection.ApplicationId}.");
+    }
+
+    internal void MarkSucceeded(
+        InstallationQueueItem item,
+        string? installedVersion,
+        PackageOperationStatus? operationStatus,
+        bool requiresReboot,
+        string? message = null)
+    {
+        item.State = InstallationQueueItemState.Succeeded;
+        item.LastOperationStatus = operationStatus;
+        item.InstalledVersion = installedVersion;
+        item.CanRetry = false;
+        item.RequiresReboot = requiresReboot;
+        item.DiagnosticCode = requiresReboot ? "installation.reboot-required" : null;
+        item.Message = message ?? (requiresReboot
+            ? $"{item.Selection.ApplicationId} was verified as installed; a reboot is required to complete the provider operation."
+            : $"{item.Selection.ApplicationId} was verified as installed.");
+        item.CompletedAtUtc = _timeProvider.GetUtcNow();
+        Publish(item, "item.succeeded", item.Message);
+    }
+
+    internal void MarkFailed(
+        InstallationQueueItem item,
+        string code,
+        string message,
+        bool canRetry,
+        PackageOperationStatus? operationStatus = null)
+    {
+        item.State = InstallationQueueItemState.Failed;
+        item.LastOperationStatus = operationStatus;
+        item.DiagnosticCode = code;
+        item.Message = message;
+        item.CanRetry = canRetry;
+        item.CompletedAtUtc = _timeProvider.GetUtcNow();
+        Publish(item, code, message);
+    }
+
+    internal void MarkCancelled(
+        InstallationQueueItem item,
+        string code,
+        string message,
+        PackageOperationStatus? operationStatus = null)
+    {
+        item.State = InstallationQueueItemState.Cancelled;
+        item.LastOperationStatus = operationStatus;
+        item.DiagnosticCode = code;
+        item.Message = message;
+        item.CanRetry = false;
+        item.CompletedAtUtc = _timeProvider.GetUtcNow();
+        Publish(item, code, message);
+    }
+
+    internal void Publish(
+        InstallationQueueItem? item,
+        string code,
+        string message) =>
+        ProgressChanged?.Invoke(
+            this,
+            new InstallationProgressEvent(
+                SessionId,
+                State,
+                item?.Snapshot(),
+                code,
+                message,
+                _timeProvider.GetUtcNow()));
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _cancellation.Dispose();
+    }
+
+    internal sealed class InstallationQueueItem(
+        int sequence,
+        InstallationSelection selection,
+        InstallationQueueItemState state,
+        string? diagnosticCode,
+        string? message)
+    {
+        public int Sequence { get; } = sequence;
+        public InstallationSelection Selection { get; } = selection;
+        public InstallationQueueItemState State { get; set; } = state;
+        public int AttemptCount { get; set; }
+        public PackageOperationStatus? LastOperationStatus { get; set; }
+        public string? DiagnosticCode { get; set; } = diagnosticCode;
+        public string? Message { get; set; } = message;
+        public string? InstalledVersion { get; set; }
+        public bool CanRetry { get; set; }
+        public bool RequiresReboot { get; set; }
+        public DateTimeOffset? StartedAtUtc { get; set; }
+        public DateTimeOffset? CompletedAtUtc { get; set; }
+
+        public InstallationItemSnapshot Snapshot() =>
+            new(
+                Sequence,
+                Selection.ApplicationId,
+                Selection.Package,
+                State,
+                AttemptCount,
+                LastOperationStatus,
+                DiagnosticCode,
+                Message,
+                InstalledVersion,
+                CanRetry,
+                RequiresReboot,
+                StartedAtUtc,
+                CompletedAtUtc);
+    }
+}

--- a/src/AgenStart.Application/Installation/InstallationSession.cs
+++ b/src/AgenStart.Application/Installation/InstallationSession.cs
@@ -137,6 +137,37 @@ public sealed class InstallationSession : IDisposable
                 : "Installation session completed.");
     }
 
+    internal void PrepareRetry(string applicationId)
+    {
+        ThrowIfDisposed();
+
+        if (State != InstallationSessionState.Completed)
+        {
+            throw new InvalidOperationException("Retries are only allowed after the installation session has completed.");
+        }
+
+        var item = _items.SingleOrDefault(candidate =>
+            string.Equals(candidate.Selection.ApplicationId, applicationId, StringComparison.OrdinalIgnoreCase));
+
+        if (item is null)
+        {
+            throw new KeyNotFoundException($"Application {applicationId} does not exist in this installation session.");
+        }
+
+        if (item.State != InstallationQueueItemState.Failed || !item.CanRetry)
+        {
+            throw new InvalidOperationException($"Application {applicationId} is not eligible for retry.");
+        }
+
+        item.State = InstallationQueueItemState.Queued;
+        item.DiagnosticCode = null;
+        item.Message = null;
+        item.CanRetry = false;
+        item.RequiresReboot = false;
+        item.CompletedAtUtc = null;
+        Publish(item, "item.retry-queued", $"{applicationId} was queued for retry.");
+    }
+
     internal void MarkQueuedItemsCancelled(string code, string message)
     {
         foreach (var item in _items.Where(static item => item.State == InstallationQueueItemState.Queued))

--- a/src/AgenStart.Application/Installation/SoftwareInventoryInstallationVerifier.cs
+++ b/src/AgenStart.Application/Installation/SoftwareInventoryInstallationVerifier.cs
@@ -1,0 +1,88 @@
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Application.Installation;
+
+public sealed class SoftwareInventoryInstallationVerifier : IInstallationVerifier
+{
+    private readonly IInstalledSoftwareInventoryProvider _inventoryProvider;
+    private readonly IReadOnlyDictionary<string, SoftwareDetectionTarget> _targets;
+    private readonly SoftwareStateResolver _resolver;
+
+    public SoftwareInventoryInstallationVerifier(
+        IInstalledSoftwareInventoryProvider inventoryProvider,
+        IEnumerable<SoftwareDetectionTarget> targets,
+        SoftwareStateResolver? resolver = null)
+    {
+        _inventoryProvider = inventoryProvider ?? throw new ArgumentNullException(nameof(inventoryProvider));
+        ArgumentNullException.ThrowIfNull(targets);
+
+        var targetMap = new Dictionary<string, SoftwareDetectionTarget>(StringComparer.OrdinalIgnoreCase);
+        foreach (var target in targets)
+        {
+            ArgumentNullException.ThrowIfNull(target);
+            if (!targetMap.TryAdd(target.ApplicationId, target))
+            {
+                throw new ArgumentException(
+                    $"Software detection target {target.ApplicationId} was registered more than once.",
+                    nameof(targets));
+            }
+        }
+
+        _targets = targetMap;
+        _resolver = resolver ?? new SoftwareStateResolver();
+    }
+
+    public async Task<InstallationVerificationResult> VerifyAsync(
+        string applicationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(applicationId))
+        {
+            throw new ArgumentException("An application id is required.", nameof(applicationId));
+        }
+
+        if (!_targets.TryGetValue(applicationId, out var target))
+        {
+            return new InstallationVerificationResult(
+                InstallationVerificationStatus.Unknown,
+                DiagnosticCode: "verification.target-missing",
+                Message: $"No software detection target exists for {applicationId}.");
+        }
+
+        try
+        {
+            var snapshot = await _inventoryProvider
+                .CaptureAsync(cancellationToken)
+                .ConfigureAwait(false);
+            var state = _resolver.Resolve([target], snapshot).Applications.Single();
+
+            return state.State switch
+            {
+                SoftwarePresenceState.Installed => new InstallationVerificationResult(
+                    InstallationVerificationStatus.Verified,
+                    state.InstalledVersion,
+                    Message: $"{applicationId} is present in the normalized software inventory."),
+                SoftwarePresenceState.Missing => new InstallationVerificationResult(
+                    InstallationVerificationStatus.NotInstalled,
+                    DiagnosticCode: "verification.not-installed",
+                    Message: $"{applicationId} was not detected after inventory refresh."),
+                _ => new InstallationVerificationResult(
+                    InstallationVerificationStatus.Unknown,
+                    DiagnosticCode: state.Diagnostics.FirstOrDefault()?.Code ?? "verification.inventory-unknown",
+                    Message: state.Diagnostics.FirstOrDefault()?.Message ??
+                        $"Installed state for {applicationId} could not be determined safely.")
+            };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            return new InstallationVerificationResult(
+                InstallationVerificationStatus.Unknown,
+                DiagnosticCode: "verification.inventory-failed",
+                Message: $"Installed-state verification failed: {exception.GetType().Name}.");
+        }
+    }
+}

--- a/tests/AgenStart.Application.Tests/AgenStart.Application.Tests.csproj
+++ b/tests/AgenStart.Application.Tests/AgenStart.Application.Tests.csproj
@@ -19,5 +19,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\AgenStart.Application\AgenStart.Application.csproj" />
     <ProjectReference Include="..\..\src\AgenStart.PackageManagement\AgenStart.PackageManagement.csproj" />
+    <ProjectReference Include="..\..\src\AgenStart.SoftwareInventory\AgenStart.SoftwareInventory.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/AgenStart.Application.Tests/AgenStart.Application.Tests.csproj
+++ b/tests/AgenStart.Application.Tests/AgenStart.Application.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgenStart.Application\AgenStart.Application.csproj" />
+    <ProjectReference Include="..\..\src\AgenStart.PackageManagement\AgenStart.PackageManagement.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/AgenStart.Application.Tests/GlobalUsings.cs
+++ b/tests/AgenStart.Application.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/AgenStart.Application.Tests/InstallationOrchestratorTests.cs
+++ b/tests/AgenStart.Application.Tests/InstallationOrchestratorTests.cs
@@ -1,0 +1,273 @@
+using AgenStart.Application.Installation;
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Application.Tests;
+
+public sealed class InstallationOrchestratorTests
+{
+    [Fact]
+    public async Task RunAsync_ExecutesOnlyApprovedItemsSequentiallyAndReportsSkippedItems()
+    {
+        var installed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var provider = new FakePackageProvider
+        {
+            OnInstall = request =>
+            {
+                installed.Add(request.ApplicationId);
+                return Success(request);
+            }
+        };
+        var verifier = new FakeVerifier(applicationId =>
+            Task.FromResult(installed.Contains(applicationId)
+                ? Verified("1.0.0")
+                : Missing()));
+        var orchestrator = new InstallationOrchestrator([provider], verifier);
+        using var session = orchestrator.CreateSession(
+        [
+            Selection("git", approved: true),
+            Selection("vlc", approved: false),
+            Selection("7zip", approved: true)
+        ]);
+
+        var report = await orchestrator.RunAsync(
+            session,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(["git", "7zip"], provider.InstallOrder);
+        Assert.Equal(2, report.SucceededCount);
+        Assert.Equal(1, report.SkippedCount);
+        Assert.Equal(0, report.FailedCount);
+        Assert.Equal(InstallationSessionState.Completed, report.State);
+        Assert.Equal(
+            InstallationQueueItemState.Skipped,
+            Assert.Single(report.Items, item => item.ApplicationId == "vlc").State);
+    }
+
+    [Fact]
+    public async Task RetryAsync_RechecksInventoryAndDoesNotRepeatACompletedInstall()
+    {
+        var provider = new FakePackageProvider();
+        var verificationResults = new Queue<InstallationVerificationResult>(
+        [
+            Missing(),
+            Missing(),
+            Verified("2.51.0")
+        ]);
+        var verifier = new FakeVerifier(_ => Task.FromResult(verificationResults.Dequeue()));
+        var orchestrator = new InstallationOrchestrator([provider], verifier);
+        using var session = orchestrator.CreateSession([Selection("git", approved: true)]);
+
+        var firstReport = await orchestrator.RunAsync(
+            session,
+            TestContext.Current.CancellationToken);
+        var failed = Assert.Single(firstReport.Items);
+
+        Assert.Equal(InstallationQueueItemState.Failed, failed.State);
+        Assert.True(failed.CanRetry);
+        Assert.Equal(1, provider.InstallCount);
+
+        var retryReport = await orchestrator.RetryAsync(
+            session,
+            "git",
+            TestContext.Current.CancellationToken);
+        var retried = Assert.Single(retryReport.Items);
+
+        Assert.Equal(InstallationQueueItemState.Succeeded, retried.State);
+        Assert.Equal(PackageOperationStatus.AlreadyInstalled, retried.LastOperationStatus);
+        Assert.Equal("2.51.0", retried.InstalledVersion);
+        Assert.Equal(1, provider.InstallCount);
+        Assert.Equal(2, retried.AttemptCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_NormalizesRetryableProviderFailure()
+    {
+        var provider = new FakePackageProvider
+        {
+            OnInstall = request => new PackageOperationResult(
+                PackageOperationStatus.NetworkFailure,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.network-failure",
+                Message: "Network unavailable.")
+        };
+        var orchestrator = new InstallationOrchestrator(
+            [provider],
+            new FakeVerifier(_ => Task.FromResult(Missing())));
+        using var session = orchestrator.CreateSession([Selection("git", approved: true)]);
+
+        var report = await orchestrator.RunAsync(
+            session,
+            TestContext.Current.CancellationToken);
+        var item = Assert.Single(report.Items);
+
+        Assert.Equal(InstallationQueueItemState.Failed, item.State);
+        Assert.Equal(PackageOperationStatus.NetworkFailure, item.LastOperationStatus);
+        Assert.Equal("winget.network-failure", item.DiagnosticCode);
+        Assert.True(item.CanRetry);
+    }
+
+    [Fact]
+    public async Task RunAsync_CancellationStopsCurrentAndRemainingQueuedItems()
+    {
+        InstallationSession? session = null;
+        var provider = new FakePackageProvider
+        {
+            OnInstall = request =>
+            {
+                session!.Cancel();
+                return new PackageOperationResult(
+                    PackageOperationStatus.Cancelled,
+                    request.ApplicationId,
+                    request.Package,
+                    DiagnosticCode: "winget.cancelled",
+                    Message: "Cancelled.");
+            }
+        };
+        var orchestrator = new InstallationOrchestrator(
+            [provider],
+            new FakeVerifier(_ => Task.FromResult(Missing())));
+        using var createdSession = orchestrator.CreateSession(
+        [
+            Selection("git", approved: true),
+            Selection("7zip", approved: true)
+        ]);
+        session = createdSession;
+
+        var report = await orchestrator.RunAsync(
+            createdSession,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(InstallationSessionState.Cancelled, report.State);
+        Assert.Equal(2, report.CancelledCount);
+        Assert.Equal(1, provider.InstallCount);
+        Assert.All(
+            report.Items,
+            item => Assert.Equal(InstallationQueueItemState.Cancelled, item.State));
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotClaimSuccessWhenPostInstallVerificationIsUnknown()
+    {
+        var results = new Queue<InstallationVerificationResult>(
+        [
+            Missing(),
+            new InstallationVerificationResult(
+                InstallationVerificationStatus.Unknown,
+                DiagnosticCode: "verification.inventory-unknown",
+                Message: "Inventory incomplete.")
+        ]);
+        var provider = new FakePackageProvider();
+        var orchestrator = new InstallationOrchestrator(
+            [provider],
+            new FakeVerifier(_ => Task.FromResult(results.Dequeue())));
+        using var session = orchestrator.CreateSession([Selection("git", approved: true)]);
+
+        var report = await orchestrator.RunAsync(
+            session,
+            TestContext.Current.CancellationToken);
+        var item = Assert.Single(report.Items);
+
+        Assert.Equal(InstallationQueueItemState.Failed, item.State);
+        Assert.Equal("verification.inventory-unknown", item.DiagnosticCode);
+        Assert.False(item.CanRetry);
+        Assert.Equal(1, provider.InstallCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_VerifiedRebootRequiredOperationIsReportedAsSuccess()
+    {
+        var results = new Queue<InstallationVerificationResult>([Missing(), Verified("5.0")]);
+        var provider = new FakePackageProvider
+        {
+            OnInstall = request => new PackageOperationResult(
+                PackageOperationStatus.RebootRequired,
+                request.ApplicationId,
+                request.Package,
+                Message: "Reboot required.")
+        };
+        var orchestrator = new InstallationOrchestrator(
+            [provider],
+            new FakeVerifier(_ => Task.FromResult(results.Dequeue())));
+        using var session = orchestrator.CreateSession([Selection("powertoys", approved: true)]);
+
+        var report = await orchestrator.RunAsync(
+            session,
+            TestContext.Current.CancellationToken);
+        var item = Assert.Single(report.Items);
+
+        Assert.Equal(InstallationQueueItemState.Succeeded, item.State);
+        Assert.True(item.RequiresReboot);
+        Assert.Equal(PackageOperationStatus.RebootRequired, item.LastOperationStatus);
+        Assert.Equal("5.0", item.InstalledVersion);
+    }
+
+    private static InstallationSelection Selection(string applicationId, bool approved) =>
+        new(
+            applicationId,
+            new ProviderPackageReference(
+                PackageProviderIds.WinGet,
+                $"Example.{applicationId}",
+                "winget"),
+            approved);
+
+    private static InstallationVerificationResult Missing() =>
+        new(InstallationVerificationStatus.NotInstalled);
+
+    private static InstallationVerificationResult Verified(string version) =>
+        new(InstallationVerificationStatus.Verified, version);
+
+    private static PackageOperationResult Success(PackageInstallRequest request) =>
+        new(
+            PackageOperationStatus.Succeeded,
+            request.ApplicationId,
+            request.Package);
+
+    private sealed class FakeVerifier(
+        Func<string, Task<InstallationVerificationResult>> verify) : IInstallationVerifier
+    {
+        public Task<InstallationVerificationResult> VerifyAsync(
+            string applicationId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return verify(applicationId);
+        }
+    }
+
+    private sealed class FakePackageProvider : IPackageProvider
+    {
+        public string ProviderId => PackageProviderIds.WinGet;
+        public Func<PackageInstallRequest, PackageOperationResult>? OnInstall { get; init; }
+        public List<string> InstallOrder { get; } = [];
+        public int InstallCount => InstallOrder.Count;
+
+        public Task<PackageProviderAvailability> CheckAvailabilityAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new PackageProviderAvailability(
+                PackageProviderAvailabilityStatus.Available,
+                "1.12.0"));
+        }
+
+        public Task<PackageResolutionResult> ResolveAsync(
+            ProviderPackageReference package,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new PackageResolutionResult(
+                PackageResolutionStatus.Resolved,
+                package));
+        }
+
+        public Task<PackageOperationResult> InstallAsync(
+            PackageInstallRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            InstallOrder.Add(request.ApplicationId);
+            return Task.FromResult(OnInstall?.Invoke(request) ?? Success(request));
+        }
+    }
+}

--- a/tests/AgenStart.Application.Tests/SoftwareInventoryInstallationVerifierTests.cs
+++ b/tests/AgenStart.Application.Tests/SoftwareInventoryInstallationVerifierTests.cs
@@ -1,0 +1,92 @@
+using AgenStart.Application.Installation;
+using AgenStart.PackageManagement;
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Application.Tests;
+
+public sealed class SoftwareInventoryInstallationVerifierTests
+{
+    [Fact]
+    public async Task VerifyAsync_UsesNormalizedInventoryStateAndReturnsInstalledVersion()
+    {
+        var package = new ProviderPackageReference(
+            PackageProviderIds.WinGet,
+            "Git.Git",
+            "winget");
+        var target = new SoftwareDetectionTarget(
+            "git",
+            "Git",
+            "Git Project",
+            [package],
+            ["Git"]);
+        var sourceId = SoftwareInventorySourceIds.ForPackageProvider(
+            PackageProviderIds.WinGet,
+            "winget");
+        var snapshot = new InstalledSoftwareSnapshot(
+            [
+                new InstalledSoftwareRecord(
+                    InstalledSoftwareSourceKind.PackageProvider,
+                    sourceId,
+                    "Git.Git",
+                    Version: "2.51.0",
+                    ProviderId: PackageProviderIds.WinGet,
+                    PackageId: "Git.Git",
+                    PackageSource: "winget")
+            ],
+            [new InventorySourceStatus(sourceId, InventorySourceState.Complete)],
+            DateTimeOffset.UnixEpoch);
+        var verifier = new SoftwareInventoryInstallationVerifier(
+            new FakeInventoryProvider(snapshot),
+            [target]);
+
+        var result = await verifier.VerifyAsync(
+            "git",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(InstallationVerificationStatus.Verified, result.Status);
+        Assert.Equal("2.51.0", result.InstalledVersion);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_DoesNotConvertIncompleteInventoryIntoMissing()
+    {
+        var package = new ProviderPackageReference(
+            PackageProviderIds.WinGet,
+            "Git.Git",
+            "winget");
+        var target = new SoftwareDetectionTarget(
+            "git",
+            "Git",
+            "Git Project",
+            [package],
+            ["Git"]);
+        var sourceId = SoftwareInventorySourceIds.ForPackageProvider(
+            PackageProviderIds.WinGet,
+            "winget");
+        var snapshot = new InstalledSoftwareSnapshot(
+            [],
+            [new InventorySourceStatus(sourceId, InventorySourceState.Partial)],
+            DateTimeOffset.UnixEpoch);
+        var verifier = new SoftwareInventoryInstallationVerifier(
+            new FakeInventoryProvider(snapshot),
+            [target]);
+
+        var result = await verifier.VerifyAsync(
+            "git",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(InstallationVerificationStatus.Unknown, result.Status);
+        Assert.Equal("inventory.insufficient-evidence", result.DiagnosticCode);
+    }
+
+    private sealed class FakeInventoryProvider(InstalledSoftwareSnapshot snapshot)
+        : IInstalledSoftwareInventoryProvider
+    {
+        public Task<InstalledSoftwareSnapshot> CaptureAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(snapshot);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the controlled installation queue and execution orchestrator for AgenStart.

### Approval and queue
- only explicitly approved selections enter `Queued`
- non-approved selections remain in the final report as `Skipped`
- deterministic sequential execution for the Windows MVP
- active-session state with sequence, attempts, timestamps and progress events

### Provider execution
- orchestrator depends only on typed `IPackageProvider`
- checks provider availability and exact resolution before installation
- no shell execution, fuzzy package lookup, source fallback or arbitrary provider arguments
- provider failures remain normalized into structured item results

### Verification
- adds `SoftwareInventoryInstallationVerifier`
- refreshes normalized installed-software inventory before and after provider execution
- skips provider execution when an app is already installed
- does not claim success unless installed state is verified
- `RebootRequired` is successful only after verification

### Retry
- explicit retry only for conservative transient/recoverable states
- no implicit provider retry
- retry re-checks installed state first
- if the previous operation actually completed, retry resolves to `AlreadyInstalled` without invoking the installer again
- integrity, policy, agreement, ambiguity and elevation states are not automatically retryable

### Cancellation
- cancellation propagates through linked cancellation tokens
- current operation becomes cancelled
- remaining queued items are cancelled without executing
- cancelled sessions are terminal in V1

### Reporting and observability
- structured progress events
- complete final report including skipped selections
- success/failure/skipped/cancelled counters
- normalized provider status, diagnostics, installed version and reboot requirement per item

### CI
- adds `Installation tests`
- runs on every relevant `push` and `pull_request`, plus manual dispatch
- covers approval, order, retry without duplicate install, normalized failure, cancellation, verification, reboot handling and real #5 inventory integration

### Documentation
- adds `docs/architecture/installation-orchestrator.md`

Closes #7