### PR TITLE
feat: initialize Avalonia desktop shell and PC analysis flow

### DIFF
--- a/.github/workflows/desktop-ui-build.yml
+++ b/.github/workflows/desktop-ui-build.yml
@@ -1,0 +1,40 @@
+name: Desktop UI build
+
+on:
+  push:
+    paths:
+      - "src/AgenStart.Desktop/**"
+      - "src/AgenStart.Core/**"
+      - "src/AgenStart.Platform.Windows/**"
+      - ".github/workflows/desktop-ui-build.yml"
+      - "global.json"
+  pull_request:
+    paths:
+      - "src/AgenStart.Desktop/**"
+      - "src/AgenStart.Core/**"
+      - "src/AgenStart.Platform.Windows/**"
+      - ".github/workflows/desktop-ui-build.yml"
+      - "global.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore
+        run: dotnet restore src/AgenStart.Desktop/AgenStart.Desktop.csproj
+
+      - name: Build
+        run: dotnet build src/AgenStart.Desktop/AgenStart.Desktop.csproj --configuration Release --no-restore --verbosity normal

--- a/src/AgenStart.Desktop/AgenStart.Desktop.csproj
+++ b/src/AgenStart.Desktop/AgenStart.Desktop.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="12.1.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgenStart.Core\AgenStart.Core.csproj" />
+    <ProjectReference Include="..\AgenStart.Platform.Windows\AgenStart.Platform.Windows.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AgenStart.Desktop/App.axaml
+++ b/src/AgenStart.Desktop/App.axaml
@@ -1,0 +1,9 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AgenStart.Desktop.App"
+             RequestedThemeVariant="Light">
+  <Application.Styles>
+    <FluentTheme />
+    <StyleInclude Source="avares://AgenStart.Desktop/Styles/AgenStartTheme.axaml" />
+  </Application.Styles>
+</Application>

--- a/src/AgenStart.Desktop/App.axaml.cs
+++ b/src/AgenStart.Desktop/App.axaml.cs
@@ -1,0 +1,21 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using AgenStart.Desktop.Views;
+
+namespace AgenStart.Desktop;
+
+public sealed partial class App : Application
+{
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/AgenStart.Desktop/Program.cs
+++ b/src/AgenStart.Desktop/Program.cs
@@ -1,0 +1,15 @@
+using Avalonia;
+
+namespace AgenStart.Desktop;
+
+internal static class Program
+{
+    [STAThread]
+    public static void Main(string[] args) =>
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+}

--- a/src/AgenStart.Desktop/Styles/AgenStartTheme.axaml
+++ b/src/AgenStart.Desktop/Styles/AgenStartTheme.axaml
@@ -1,0 +1,103 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Styles.Resources>
+    <Color x:Key="AgenNavColor">#0A1D29</Color>
+    <Color x:Key="AgenSurfaceColor">#F7F5EF</Color>
+    <Color x:Key="AgenTextColor">#10242B</Color>
+    <Color x:Key="AgenMutedColor">#69747A</Color>
+    <Color x:Key="AgenTealColor">#176D64</Color>
+    <Color x:Key="AgenAccentColor">#45CFC1</Color>
+    <Color x:Key="AgenDividerColor">#D9DEDC</Color>
+
+    <SolidColorBrush x:Key="AgenNavBrush" Color="{StaticResource AgenNavColor}" />
+    <SolidColorBrush x:Key="AgenSurfaceBrush" Color="{StaticResource AgenSurfaceColor}" />
+    <SolidColorBrush x:Key="AgenTextBrush" Color="{StaticResource AgenTextColor}" />
+    <SolidColorBrush x:Key="AgenMutedBrush" Color="{StaticResource AgenMutedColor}" />
+    <SolidColorBrush x:Key="AgenTealBrush" Color="{StaticResource AgenTealColor}" />
+    <SolidColorBrush x:Key="AgenAccentBrush" Color="{StaticResource AgenAccentColor}" />
+    <SolidColorBrush x:Key="AgenDividerBrush" Color="{StaticResource AgenDividerColor}" />
+  </Styles.Resources>
+
+  <Style Selector="Window">
+    <Setter Property="Background" Value="{StaticResource AgenSurfaceBrush}" />
+    <Setter Property="FontFamily" Value="Segoe UI" />
+    <Setter Property="Foreground" Value="{StaticResource AgenTextBrush}" />
+  </Style>
+
+  <Style Selector="Button.nav">
+    <Setter Property="Height" Value="58" />
+    <Setter Property="Margin" Value="12,3" />
+    <Setter Property="Padding" Value="18,0" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="#DDE6EA" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="CornerRadius" Value="8" />
+    <Setter Property="FontSize" Value="16" />
+  </Style>
+
+  <Style Selector="Button.nav:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="#15333E" />
+  </Style>
+
+  <Style Selector="Button.nav.active /template/ ContentPresenter">
+    <Setter Property="Background" Value="#173B45" />
+  </Style>
+
+  <Style Selector="Button.nav:disabled">
+    <Setter Property="Opacity" Value="0.38" />
+  </Style>
+
+  <Style Selector="Button.primary">
+    <Setter Property="MinWidth" Value="220" />
+    <Setter Property="Height" Value="54" />
+    <Setter Property="Padding" Value="24,0" />
+    <Setter Property="Background" Value="{StaticResource AgenTealBrush}" />
+    <Setter Property="Foreground" Value="White" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="CornerRadius" Value="8" />
+    <Setter Property="FontSize" Value="16" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+  </Style>
+
+  <Style Selector="Button.primary:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="#145E57" />
+  </Style>
+
+  <Style Selector="Button.secondary">
+    <Setter Property="MinWidth" Value="190" />
+    <Setter Property="Height" Value="54" />
+    <Setter Property="Padding" Value="22,0" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{StaticResource AgenTextBrush}" />
+    <Setter Property="BorderBrush" Value="#AAB2B2" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="8" />
+    <Setter Property="FontSize" Value="16" />
+  </Style>
+
+  <Style Selector="TextBlock.eyebrow">
+    <Setter Property="Foreground" Value="{StaticResource AgenTealBrush}" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="FontSize" Value="14" />
+    <Setter Property="LetterSpacing" Value="2" />
+  </Style>
+
+  <Style Selector="TextBlock.pageTitle">
+    <Setter Property="Foreground" Value="{StaticResource AgenTextBrush}" />
+    <Setter Property="FontSize" Value="48" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+  </Style>
+
+  <Style Selector="TextBlock.subtitle">
+    <Setter Property="Foreground" Value="{StaticResource AgenMutedBrush}" />
+    <Setter Property="FontSize" Value="17" />
+    <Setter Property="LineHeight" Value="25" />
+  </Style>
+
+  <Style Selector="Border.dataRow">
+    <Setter Property="BorderBrush" Value="{StaticResource AgenDividerBrush}" />
+    <Setter Property="BorderThickness" Value="0,0,0,1" />
+    <Setter Property="Padding" Value="8,13" />
+  </Style>
+</Styles>

--- a/src/AgenStart.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/src/AgenStart.Desktop/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,235 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using AgenStart.Core.Machine;
+using AgenStart.Platform.Windows.Inventory;
+
+namespace AgenStart.Desktop.ViewModels;
+
+public sealed class MainWindowViewModel : INotifyPropertyChanged
+{
+    private readonly IMachineInventoryProvider _machineInventory;
+    private bool _isBusy;
+    private bool _hasSnapshot;
+    private string _statusTitle = "Ready for analysis";
+    private string _statusMessage = "AgenStart can inspect the essential capabilities of this PC locally.";
+    private string _operatingSystem = "Not analysed";
+    private string _cpu = "Not analysed";
+    private string _memory = "Not analysed";
+    private string _gpu = "Not analysed";
+    private string _systemDrive = "Not analysed";
+    private string _freeSpace = "Not analysed";
+    private string _architecture = "Not analysed";
+    private string _winGet = "Not analysed";
+    private string _winGetVersion = "Not analysed";
+    private string _analysisDiagnostic = "No personal files or account information are inspected.";
+
+    public MainWindowViewModel(IMachineInventoryProvider? machineInventory = null)
+    {
+        _machineInventory = machineInventory ?? new WindowsMachineInventoryProvider();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set => SetField(ref _isBusy, value);
+    }
+
+    public bool HasSnapshot
+    {
+        get => _hasSnapshot;
+        private set => SetField(ref _hasSnapshot, value);
+    }
+
+    public string StatusTitle
+    {
+        get => _statusTitle;
+        private set => SetField(ref _statusTitle, value);
+    }
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        private set => SetField(ref _statusMessage, value);
+    }
+
+    public string OperatingSystem
+    {
+        get => _operatingSystem;
+        private set => SetField(ref _operatingSystem, value);
+    }
+
+    public string Cpu
+    {
+        get => _cpu;
+        private set => SetField(ref _cpu, value);
+    }
+
+    public string Memory
+    {
+        get => _memory;
+        private set => SetField(ref _memory, value);
+    }
+
+    public string Gpu
+    {
+        get => _gpu;
+        private set => SetField(ref _gpu, value);
+    }
+
+    public string SystemDrive
+    {
+        get => _systemDrive;
+        private set => SetField(ref _systemDrive, value);
+    }
+
+    public string FreeSpace
+    {
+        get => _freeSpace;
+        private set => SetField(ref _freeSpace, value);
+    }
+
+    public string Architecture
+    {
+        get => _architecture;
+        private set => SetField(ref _architecture, value);
+    }
+
+    public string WinGet
+    {
+        get => _winGet;
+        private set => SetField(ref _winGet, value);
+    }
+
+    public string WinGetVersion
+    {
+        get => _winGetVersion;
+        private set => SetField(ref _winGetVersion, value);
+    }
+
+    public string AnalysisDiagnostic
+    {
+        get => _analysisDiagnostic;
+        private set => SetField(ref _analysisDiagnostic, value);
+    }
+
+    public async Task AnalyzeAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        StatusTitle = "Analysing this PC";
+        StatusMessage = "Reading essential system capabilities locally…";
+
+        try
+        {
+            var snapshot = await _machineInventory.CaptureAsync(cancellationToken).ConfigureAwait(true);
+            ApplySnapshot(snapshot);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            StatusTitle = "Analysis cancelled";
+            StatusMessage = "No changes were made to this PC.";
+        }
+        catch (Exception)
+        {
+            StatusTitle = "Analysis unavailable";
+            StatusMessage = "AgenStart could not complete the local machine analysis.";
+            AnalysisDiagnostic = "Try the analysis again. No machine changes were made.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void ApplySnapshot(MachineSnapshot snapshot)
+    {
+        HasSnapshot = snapshot.Platform.Kind == PlatformKind.Windows;
+
+        OperatingSystem = snapshot.Platform.Edition
+            ?? (snapshot.Platform.Kind == PlatformKind.Windows ? "Windows" : "Unsupported platform");
+        Cpu = snapshot.Cpu.Model ?? "CPU detected";
+        Memory = FormatBytes(snapshot.Memory.TotalPhysicalBytes);
+        Gpu = snapshot.Gpus.FirstOrDefault()?.Name ?? "Unknown";
+
+        var systemDrive = snapshot.SystemDrive;
+        SystemDrive = systemDrive is null
+            ? "Unknown"
+            : $"{FormatBytes(systemDrive.TotalBytes)} system drive";
+        FreeSpace = systemDrive is null
+            ? "Unknown"
+            : $"{FormatBytes(systemDrive.AvailableBytes)} free";
+
+        Architecture = FormatArchitecture(snapshot.Platform.Architecture);
+        WinGet = snapshot.PackageManager.State == CapabilityState.Available
+            ? "Available"
+            : snapshot.PackageManager.State.ToString();
+        WinGetVersion = snapshot.PackageManager.Version?.ToString() ?? "Unknown";
+
+        if (snapshot.Platform.Kind == PlatformKind.Windows)
+        {
+            StatusTitle = "PC ready";
+            StatusMessage = "Essential capabilities detected locally.";
+        }
+        else
+        {
+            StatusTitle = "Unsupported platform";
+            StatusMessage = "The current AgenStart MVP supports Windows 10 and 11.";
+        }
+
+        AnalysisDiagnostic = snapshot.Diagnostics.Count == 0
+            ? "No personal files or account information are inspected."
+            : $"Analysis completed with {snapshot.Diagnostics.Count.ToString(CultureInfo.InvariantCulture)} diagnostic note(s). No personal files were inspected.";
+    }
+
+    private static string FormatArchitecture(MachineArchitecture architecture) => architecture switch
+    {
+        MachineArchitecture.X64 => "x64 architecture",
+        MachineArchitecture.X86 => "x86 architecture",
+        MachineArchitecture.Arm64 => "ARM64 architecture",
+        _ => "Unknown architecture"
+    };
+
+    private static string FormatBytes(ulong? bytes)
+    {
+        if (bytes is null)
+        {
+            return "Unknown";
+        }
+
+        return FormatBytes((double)bytes.Value);
+    }
+
+    private static string FormatBytes(long? bytes)
+    {
+        if (bytes is null || bytes < 0)
+        {
+            return "Unknown";
+        }
+
+        return FormatBytes((double)bytes.Value);
+    }
+
+    private static string FormatBytes(double bytes)
+    {
+        const double gib = 1024d * 1024d * 1024d;
+        return $"{Math.Round(bytes / gib):0} GB";
+    }
+
+    private void SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/AgenStart.Desktop/Views/MainWindow.axaml
+++ b/src/AgenStart.Desktop/Views/MainWindow.axaml
@@ -1,0 +1,157 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:AgenStart.Desktop.ViewModels"
+        x:Class="AgenStart.Desktop.Views.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
+        mc:Ignorable="d"
+        Title="AgenStart"
+        Width="1600"
+        Height="1000"
+        MinWidth="1100"
+        MinHeight="720">
+  <Grid ColumnDefinitions="280,*">
+    <Border Grid.Column="0" Background="{StaticResource AgenNavBrush}">
+      <Grid RowDefinitions="Auto,*,Auto" Margin="0,30,0,24">
+        <StackPanel Margin="30,0,20,28">
+          <TextBlock Text="AgenStart" Foreground="White" FontSize="29" FontWeight="SemiBold" />
+          <TextBlock Text="BY AGENSTUDIO" Foreground="{StaticResource AgenAccentBrush}" FontSize="11" FontWeight="SemiBold" LetterSpacing="2.4" Margin="0,5,0,0" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Spacing="1">
+          <Grid>
+            <Border x:Name="OverviewStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" />
+            <Button x:Name="OverviewButton" Classes="nav active" Click="OverviewButton_OnClick">
+              <StackPanel Orientation="Horizontal" Spacing="14">
+                <TextBlock Text="⌂" FontSize="22" Width="24" TextAlignment="Center" />
+                <TextBlock Text="Overview" VerticalAlignment="Center" />
+              </StackPanel>
+            </Button>
+          </Grid>
+          <Grid>
+            <Border x:Name="YourPcStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" IsVisible="False" />
+            <Button x:Name="YourPcButton" Classes="nav" Click="YourPcButton_OnClick">
+              <StackPanel Orientation="Horizontal" Spacing="14">
+                <TextBlock Text="▣" FontSize="18" Width="24" TextAlignment="Center" />
+                <TextBlock Text="Your PC" VerticalAlignment="Center" />
+              </StackPanel>
+            </Button>
+          </Grid>
+          <Button Classes="nav" IsEnabled="False">
+            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="○" FontSize="21" Width="24" TextAlignment="Center" /><TextBlock Text="Usage profile" VerticalAlignment="Center" /></StackPanel>
+          </Button>
+          <Button Classes="nav" IsEnabled="False">
+            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="✦" FontSize="20" Width="24" TextAlignment="Center" /><TextBlock Text="Recommendations" VerticalAlignment="Center" /></StackPanel>
+          </Button>
+          <Button Classes="nav" IsEnabled="False">
+            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="✓" FontSize="20" Width="24" TextAlignment="Center" /><TextBlock Text="Review" VerticalAlignment="Center" /></StackPanel>
+          </Button>
+          <Button Classes="nav" IsEnabled="False">
+            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="↓" FontSize="21" Width="24" TextAlignment="Center" /><TextBlock Text="Installation" VerticalAlignment="Center" /></StackPanel>
+          </Button>
+          <Button Classes="nav" IsEnabled="False">
+            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="▤" FontSize="18" Width="24" TextAlignment="Center" /><TextBlock Text="Report" VerticalAlignment="Center" /></StackPanel>
+          </Button>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Spacing="1">
+          <Border Height="1" Background="#35505A" Margin="20,0,20,14" />
+          <Button Classes="nav" IsEnabled="False">
+            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="↶" FontSize="22" Width="24" TextAlignment="Center" /><TextBlock Text="History" VerticalAlignment="Center" /></StackPanel>
+          </Button>
+          <Button Classes="nav" IsEnabled="False">
+            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="⚙" FontSize="20" Width="24" TextAlignment="Center" /><TextBlock Text="Settings" VerticalAlignment="Center" /></StackPanel>
+          </Button>
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <Grid Grid.Column="1" Background="{StaticResource AgenSurfaceBrush}">
+      <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+        <Grid Margin="72,62,72,54">
+          <Grid x:Name="OverviewPanel">
+            <Grid ColumnDefinitions="1.05*,0.95*" ColumnSpacing="64" MaxWidth="1180" HorizontalAlignment="Left">
+              <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="0">
+                <TextBlock Classes="eyebrow" Text="OVERVIEW" Margin="0,0,0,28" />
+                <TextBlock Classes="pageTitle" Text="Let's prepare this PC." />
+                <TextBlock Classes="subtitle" Text="AgenStart will inspect this machine locally before recommending anything." TextWrapping="Wrap" Margin="0,20,0,0" MaxWidth="570" HorizontalAlignment="Left" />
+                <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,38,0,38" />
+
+                <TextBlock Text="Start with a local machine analysis" FontSize="20" FontWeight="SemiBold" />
+                <TextBlock Classes="subtitle" Text="We'll detect Windows, CPU, memory, graphics, storage and WinGet without reading your personal files." TextWrapping="Wrap" Margin="0,9,0,26" />
+
+                <StackPanel Orientation="Horizontal" Spacing="14">
+                  <Button x:Name="AnalyzeButton" Classes="primary" Click="AnalyzeButton_OnClick" Content="Analyse this PC" />
+                  <Button Classes="secondary" Content="Import a setup" IsEnabled="False" />
+                </StackPanel>
+
+                <ProgressBar IsIndeterminate="True" IsVisible="{Binding IsBusy}" Height="3" Margin="0,18,80,0" />
+                <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,40,0,0">
+                  <TextBlock Text="▱" Foreground="{StaticResource AgenTealBrush}" FontSize="21" />
+                  <TextBlock Text="Machine analysis stays on this device." Foreground="{StaticResource AgenMutedBrush}" FontSize="14" VerticalAlignment="Center" />
+                </StackPanel>
+              </StackPanel>
+
+              <Grid Grid.Column="1" RowDefinitions="*,Auto,*" VerticalAlignment="Center" MinHeight="500">
+                <Border Grid.Row="0" />
+                <StackPanel Grid.Row="1" HorizontalAlignment="Center" Width="390" Spacing="12">
+                  <Border Width="74" Height="74" CornerRadius="37" BorderThickness="2" BorderBrush="{StaticResource AgenTealBrush}" HorizontalAlignment="Center">
+                    <TextBlock Text="✓" FontSize="35" Foreground="{StaticResource AgenTealBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                  </Border>
+                  <TextBlock Text="{Binding StatusTitle}" FontSize="26" FontWeight="SemiBold" TextAlignment="Center" Margin="0,9,0,0" />
+                  <TextBlock Text="{Binding StatusMessage}" Classes="subtitle" TextAlignment="Center" TextWrapping="Wrap" />
+                  <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,16,0,12" />
+                  <TextBlock Text="You stay in control of what gets installed." Foreground="{StaticResource AgenMutedBrush}" FontSize="14" TextAlignment="Center" />
+                </StackPanel>
+                <Border Grid.Row="2" />
+              </Grid>
+            </Grid>
+          </Grid>
+
+          <Grid x:Name="YourPcPanel" IsVisible="False" MaxWidth="1120" HorizontalAlignment="Left">
+            <Grid RowDefinitions="Auto,Auto,*">
+              <StackPanel Grid.Row="0">
+                <TextBlock Classes="eyebrow" Text="YOUR PC" Margin="0,0,0,22" />
+                <TextBlock Classes="pageTitle" Text="Your PC" />
+                <TextBlock Classes="subtitle" Text="AgenStart detected the essentials locally." Margin="0,13,0,0" />
+                <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,30,0,26" />
+              </StackPanel>
+
+              <Grid Grid.Row="1" ColumnDefinitions="1.35*,0.65*" ColumnSpacing="52">
+                <StackPanel Grid.Column="0">
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="▣" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding OperatingSystem}" FontSize="17" /><TextBlock Grid.Column="2" Text="Detected" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="◉" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding Cpu}" FontSize="17" /><TextBlock Grid.Column="2" Text="Detected" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="▥" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding Memory}" FontSize="17" /><TextBlock Grid.Column="2" Text="Available" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="◇" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding Gpu}" FontSize="17" /><TextBlock Grid.Column="2" Text="Detected" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="▰" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding SystemDrive}" FontSize="17" /><TextBlock Grid.Column="2" Text="Available" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="◌" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding FreeSpace}" FontSize="17" /><TextBlock Grid.Column="2" Text="Available" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="64" FontSize="13" FontWeight="Bold" /><TextBlock Grid.Column="1" Text="{Binding Architecture}" FontSize="17" /><TextBlock Grid.Column="2" Text="Supported" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="⬡" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding WinGet}" FontSize="17" /><TextBlock Grid.Column="2" Text="Available" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+                  <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="i" FontSize="18" FontWeight="SemiBold" /><TextBlock Grid.Column="1" Text="{Binding WinGetVersion, StringFormat='WinGet version {0}'}" FontSize="17" /><TextBlock Grid.Column="2" Text="Detected" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
+
+                  <Button x:Name="RefreshButton" Classes="secondary" Content="Refresh analysis" HorizontalAlignment="Left" Margin="0,26,0,0" Click="RefreshButton_OnClick" />
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" Width="310" Spacing="12">
+                  <Border Width="74" Height="74" CornerRadius="37" BorderThickness="2" BorderBrush="{StaticResource AgenTealBrush}" HorizontalAlignment="Center">
+                    <TextBlock Text="✓" FontSize="35" Foreground="{StaticResource AgenTealBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                  </Border>
+                  <TextBlock Text="{Binding StatusTitle}" FontSize="25" FontWeight="SemiBold" TextAlignment="Center" Margin="0,8,0,0" />
+                  <TextBlock Text="{Binding StatusMessage}" Classes="subtitle" TextWrapping="Wrap" TextAlignment="Center" />
+                </StackPanel>
+              </Grid>
+
+              <Border Grid.Row="2" BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,1,0,0" Margin="0,30,0,0" Padding="0,24,0,0">
+                <StackPanel Orientation="Horizontal" Spacing="12">
+                  <TextBlock Text="▱" Foreground="{StaticResource AgenTealBrush}" FontSize="21" />
+                  <TextBlock Text="{Binding AnalysisDiagnostic}" Foreground="{StaticResource AgenMutedBrush}" FontSize="14" VerticalAlignment="Center" />
+                </StackPanel>
+              </Border>
+            </Grid>
+          </Grid>
+        </Grid>
+      </ScrollViewer>
+    </Grid>
+  </Grid>
+</Window>

--- a/src/AgenStart.Desktop/Views/MainWindow.axaml.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.axaml.cs
@@ -1,0 +1,86 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using AgenStart.Desktop.ViewModels;
+
+namespace AgenStart.Desktop.Views;
+
+public sealed partial class MainWindow : Window
+{
+    private readonly CancellationTokenSource _lifetimeCancellation = new();
+    private readonly MainWindowViewModel _viewModel;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        _viewModel = new MainWindowViewModel();
+        DataContext = _viewModel;
+
+        YourPcButton.IsEnabled = false;
+        Closed += OnClosed;
+    }
+
+    private void OverviewButton_OnClick(object? sender, RoutedEventArgs e) => ShowOverview();
+
+    private void YourPcButton_OnClick(object? sender, RoutedEventArgs e) => ShowYourPc();
+
+    private async void AnalyzeButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        await _viewModel.AnalyzeAsync(_lifetimeCancellation.Token);
+        if (_viewModel.HasSnapshot)
+        {
+            YourPcButton.IsEnabled = true;
+            ShowYourPc();
+        }
+    }
+
+    private async void RefreshButton_OnClick(object? sender, RoutedEventArgs e) =>
+        await _viewModel.AnalyzeAsync(_lifetimeCancellation.Token);
+
+    private void ShowOverview()
+    {
+        OverviewPanel.IsVisible = true;
+        YourPcPanel.IsVisible = false;
+        OverviewStripe.IsVisible = true;
+        YourPcStripe.IsVisible = false;
+        SetActive(OverviewButton, true);
+        SetActive(YourPcButton, false);
+    }
+
+    private void ShowYourPc()
+    {
+        if (!YourPcButton.IsEnabled)
+        {
+            return;
+        }
+
+        OverviewPanel.IsVisible = false;
+        YourPcPanel.IsVisible = true;
+        OverviewStripe.IsVisible = false;
+        YourPcStripe.IsVisible = true;
+        SetActive(OverviewButton, false);
+        SetActive(YourPcButton, true);
+    }
+
+    private static void SetActive(Button button, bool isActive)
+    {
+        const string activeClass = "active";
+        if (isActive)
+        {
+            if (!button.Classes.Contains(activeClass))
+            {
+                button.Classes.Add(activeClass);
+            }
+        }
+        else
+        {
+            button.Classes.Remove(activeClass);
+        }
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        _lifetimeCancellation.Cancel();
+        _lifetimeCancellation.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

Starts the desktop implementation for #8 from the approved AgenStart UI reference.

### Desktop foundation
- adds `AgenStart.Desktop` on .NET 10 + Avalonia 12.1.2
- introduces the approved navy / warm off-white / teal design tokens
- adds the persistent guided-workflow sidebar
- keeps unfinished workflow steps visibly disabled instead of presenting fake navigation
- adds a Windows desktop build gate

### First functional vertical slice
- implements the Overview screen
- implements the Your PC screen
- wires `Analyse this PC` to the real `WindowsMachineInventoryProvider`
- surfaces OS, CPU, RAM, GPU, storage, architecture and WinGet data from the normalized `MachineSnapshot`
- uses semantic states such as Detected / Available / Supported instead of generic hardware compatibility claims
- keeps analysis local and read-only
- enables Your PC only after a successful Windows snapshot

### Scope boundary
This PR intentionally does not implement Usage profile, Recommendations, Review, Installation, Report, History or Settings yet. Those remain disabled until their corresponding flows are actually wired.

Part of #8.