### PR TITLE
feat: load curated software catalogue at runtime

### DIFF
--- a/.github/workflows/catalogue-tests.yml
+++ b/.github/workflows/catalogue-tests.yml
@@ -1,0 +1,46 @@
+name: Catalogue tests
+
+on:
+  push:
+    paths:
+      - "src/AgenStart.Catalogue/**"
+      - "src/AgenStart.Core/**"
+      - "src/AgenStart.PackageManagement/**"
+      - "src/AgenStart.SoftwareInventory/**"
+      - "tests/AgenStart.Catalogue.Tests/**"
+      - "docs/product/catalogue.fixtures.json"
+      - ".github/workflows/catalogue-tests.yml"
+      - "global.json"
+  pull_request:
+    paths:
+      - "src/AgenStart.Catalogue/**"
+      - "src/AgenStart.Core/**"
+      - "src/AgenStart.PackageManagement/**"
+      - "src/AgenStart.SoftwareInventory/**"
+      - "tests/AgenStart.Catalogue.Tests/**"
+      - "docs/product/catalogue.fixtures.json"
+      - ".github/workflows/catalogue-tests.yml"
+      - "global.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore
+        run: dotnet restore tests/AgenStart.Catalogue.Tests/AgenStart.Catalogue.Tests.csproj
+
+      - name: Test
+        run: dotnet test tests/AgenStart.Catalogue.Tests/AgenStart.Catalogue.Tests.csproj --configuration Release --no-restore --verbosity normal

--- a/src/AgenStart.Catalogue/AgenStart.Catalogue.csproj
+++ b/src/AgenStart.Catalogue/AgenStart.Catalogue.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AgenStart.Core\AgenStart.Core.csproj" />
+    <ProjectReference Include="..\AgenStart.PackageManagement\AgenStart.PackageManagement.csproj" />
+    <ProjectReference Include="..\AgenStart.SoftwareInventory\AgenStart.SoftwareInventory.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AgenStart.Catalogue/SoftwareCatalogue.cs
+++ b/src/AgenStart.Catalogue/SoftwareCatalogue.cs
@@ -1,0 +1,39 @@
+using AgenStart.Core.Catalogue;
+using AgenStart.PackageManagement;
+using AgenStart.SoftwareInventory;
+
+namespace AgenStart.Catalogue;
+
+public sealed record SoftwareCatalogue(
+    string SchemaVersion,
+    string CatalogueVersion,
+    IReadOnlyList<CatalogueApplication> Applications)
+{
+    public IReadOnlyList<ApplicationDefinition> Definitions =>
+        Applications.Select(static application => application.Definition).ToArray();
+
+    public IReadOnlyList<SoftwareDetectionTarget> DetectionTargets =>
+        Applications.Select(static application => application.DetectionTarget).ToArray();
+}
+
+public sealed record CatalogueApplication(
+    ApplicationDefinition Definition,
+    string Publisher,
+    string Description,
+    IReadOnlyList<ProviderPackageReference> ProviderPackages,
+    IReadOnlyList<string> RegistryDisplayNames)
+{
+    public string Id => Definition.Id;
+    public string Name => Definition.Name;
+
+    public SoftwareDetectionTarget DetectionTarget => new(
+        Definition.Id,
+        Definition.Name,
+        Publisher,
+        ProviderPackages,
+        RegistryDisplayNames);
+
+    public ProviderPackageReference? WindowsPackage =>
+        ProviderPackages.FirstOrDefault(static package =>
+            string.Equals(package.ProviderId, PackageProviderIds.WinGet, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/AgenStart.Catalogue/SoftwareCatalogueLoader.cs
+++ b/src/AgenStart.Catalogue/SoftwareCatalogueLoader.cs
@@ -1,0 +1,378 @@
+using System.Text.Json;
+using AgenStart.Core.Catalogue;
+using AgenStart.Core.Machine;
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Catalogue;
+
+public sealed class SoftwareCatalogueLoader
+{
+    private const string SupportedSchemaVersion = "1.0.0";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public SoftwareCatalogue Load(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var document = JsonSerializer.Deserialize<CatalogueDocumentDto>(stream, JsonOptions)
+            ?? throw new InvalidDataException("The software catalogue is empty or invalid JSON.");
+
+        return Map(document);
+    }
+
+    public SoftwareCatalogue Load(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        return Load(stream);
+    }
+
+    private static SoftwareCatalogue Map(CatalogueDocumentDto document)
+    {
+        var schemaVersion = RequireText(document.SchemaVersion, "schemaVersion");
+        if (!string.Equals(schemaVersion, SupportedSchemaVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Unsupported catalogue schema version '{schemaVersion}'. Expected {SupportedSchemaVersion}.");
+        }
+
+        var catalogueVersion = RequireText(document.CatalogueVersion, "catalogueVersion");
+        if (document.Applications is null || document.Applications.Count == 0)
+        {
+            throw new InvalidDataException("The catalogue must contain at least one application.");
+        }
+
+        var applications = new List<CatalogueApplication>(document.Applications.Count);
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var dto in document.Applications)
+        {
+            var application = MapApplication(dto);
+            if (!ids.Add(application.Id))
+            {
+                throw new InvalidDataException($"Duplicate catalogue application id '{application.Id}'.");
+            }
+
+            applications.Add(application);
+        }
+
+        return new SoftwareCatalogue(schemaVersion, catalogueVersion, applications);
+    }
+
+    private static CatalogueApplication MapApplication(ApplicationDto dto)
+    {
+        var id = RequireText(dto.Id, "application.id");
+        var name = RequireText(dto.Name, $"application[{id}].name");
+        var publisher = RequireText(dto.Publisher, $"application[{id}].publisher");
+        var description = RequireText(dto.Description, $"application[{id}].description");
+        var lifecycle = ParseLifecycle(dto.Lifecycle?.Status, id);
+
+        if (dto.Recommendations is null)
+        {
+            throw new InvalidDataException($"Application '{id}' is missing recommendations.");
+        }
+
+        var recommendations = dto.Recommendations
+            .Select(rule => new ProfileRecommendation(
+                ParseProfile(rule.Profile, id),
+                ParseRecommendationLevel(rule.Level, id),
+                RequireText(rule.ReasonKey, $"application[{id}].recommendations.reasonKey")))
+            .ToArray();
+
+        var requirements = new ApplicationRequirements(
+            MapCapabilities(dto.Requirements?.Minimum, id, "minimum"),
+            MapCapabilities(dto.Requirements?.Recommended, id, "recommended"));
+
+        if (dto.PlatformSupport is null || dto.PlatformSupport.Count == 0)
+        {
+            throw new InvalidDataException($"Application '{id}' is missing platform support rules.");
+        }
+
+        var platformSupport = dto.PlatformSupport
+            .Select(rule => new PlatformSupportRule(
+                ParsePlatform(rule.Platform, id),
+                ParsePlatformSupport(rule.Status, id),
+                ParseArchitectures(rule.Architectures, id, "platformSupport")))
+            .ToArray();
+
+        var providers = MapWindowsProviders(dto.Providers, id);
+        var supportsWindows = platformSupport.Any(rule =>
+            rule.Platform == PlatformKind.Windows && rule.Status == PlatformSupportStatus.Supported);
+
+        if (lifecycle == ApplicationLifecycleStatus.Active && supportsWindows && providers.Count == 0)
+        {
+            throw new InvalidDataException(
+                $"Active Windows application '{id}' has no trusted WinGet provider mapping.");
+        }
+
+        var aliases = dto.RegistryDisplayNames is { Count: > 0 }
+            ? dto.RegistryDisplayNames.Select(alias => RequireText(alias, $"application[{id}].registryDisplayNames")).Distinct(StringComparer.OrdinalIgnoreCase).ToArray()
+            : [name];
+
+        var definition = new ApplicationDefinition(
+            id,
+            name,
+            lifecycle,
+            recommendations,
+            requirements,
+            platformSupport,
+            NormalizeIds(dto.Dependencies, id, "dependencies"),
+            NormalizeIds(dto.Conflicts, id, "conflicts"));
+
+        return new CatalogueApplication(definition, publisher, description, providers, aliases);
+    }
+
+    private static CapabilityRequirements MapCapabilities(
+        CapabilityRequirementsDto? dto,
+        string applicationId,
+        string label)
+    {
+        if (dto is null)
+        {
+            throw new InvalidDataException($"Application '{applicationId}' is missing {label} requirements.");
+        }
+
+        if (dto.MinRamMiB is < 0 || dto.MinFreeStorageMiB is < 0)
+        {
+            throw new InvalidDataException($"Application '{applicationId}' contains negative {label} requirements.");
+        }
+
+        return new CapabilityRequirements(
+            dto.MinRamMiB,
+            dto.MinFreeStorageMiB,
+            dto.GpuRequired,
+            ParseArchitectures(dto.Architectures, applicationId, label));
+    }
+
+    private static IReadOnlyList<ProviderPackageReference> MapWindowsProviders(
+        IReadOnlyList<ProviderDto>? providers,
+        string applicationId)
+    {
+        if (providers is null)
+        {
+            return [];
+        }
+
+        var result = new List<ProviderPackageReference>();
+        foreach (var provider in providers)
+        {
+            var platform = ParsePlatform(provider.Platform, applicationId);
+            if (platform != PlatformKind.Windows)
+            {
+                continue;
+            }
+
+            var type = RequireText(provider.Type, $"application[{applicationId}].providers.type");
+            if (!string.Equals(type, "winget", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException(
+                    $"Unsupported Windows package provider type '{type}' for '{applicationId}'.");
+            }
+
+            var packageId = RequireText(provider.PackageId, $"application[{applicationId}].providers.packageId");
+            ValidatePackageId(packageId, applicationId);
+
+            var source = RequireText(provider.Source, $"application[{applicationId}].providers.source").ToLowerInvariant();
+            if (source is not ("winget" or "msstore"))
+            {
+                throw new InvalidDataException(
+                    $"Untrusted WinGet source '{source}' for '{applicationId}'.");
+            }
+
+            result.Add(new ProviderPackageReference(
+                PackageProviderIds.WinGet,
+                packageId,
+                source,
+                ParseScope(provider.ScopePreference, applicationId)));
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyList<string> NormalizeIds(
+        IReadOnlyList<string>? values,
+        string applicationId,
+        string field)
+    {
+        if (values is null)
+        {
+            return [];
+        }
+
+        return values
+            .Select(value => RequireText(value, $"application[{applicationId}].{field}"))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<MachineArchitecture> ParseArchitectures(
+        IReadOnlyList<string>? values,
+        string applicationId,
+        string field)
+    {
+        if (values is null || values.Count == 0)
+        {
+            throw new InvalidDataException(
+                $"Application '{applicationId}' must declare at least one architecture for {field}.");
+        }
+
+        return values.Select(value => value?.Trim().ToLowerInvariant() switch
+        {
+            "x86" => MachineArchitecture.X86,
+            "x64" => MachineArchitecture.X64,
+            "arm64" => MachineArchitecture.Arm64,
+            _ => throw new InvalidDataException(
+                $"Unsupported architecture '{value}' for application '{applicationId}'.")
+        }).Distinct().ToArray();
+    }
+
+    private static UserProfile ParseProfile(string? value, string applicationId) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            "personal" => UserProfile.Personal,
+            "development" => UserProfile.Development,
+            "business" => UserProfile.Business,
+            "creation" => UserProfile.Creation,
+            "training" => UserProfile.Training,
+            _ => throw new InvalidDataException(
+                $"Unsupported profile '{value}' for application '{applicationId}'.")
+        };
+
+    private static RecommendationLevel ParseRecommendationLevel(string? value, string applicationId) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            "essential" => RecommendationLevel.Essential,
+            "recommended" => RecommendationLevel.Recommended,
+            "optional" => RecommendationLevel.Optional,
+            _ => throw new InvalidDataException(
+                $"Unsupported recommendation level '{value}' for application '{applicationId}'.")
+        };
+
+    private static ApplicationLifecycleStatus ParseLifecycle(string? value, string applicationId) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            "active" => ApplicationLifecycleStatus.Active,
+            "deprecated" => ApplicationLifecycleStatus.Deprecated,
+            "blocked" => ApplicationLifecycleStatus.Blocked,
+            _ => throw new InvalidDataException(
+                $"Unsupported lifecycle status '{value}' for application '{applicationId}'.")
+        };
+
+    private static PlatformKind ParsePlatform(string? value, string applicationId) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            "windows" => PlatformKind.Windows,
+            "macos" => PlatformKind.MacOS,
+            _ => throw new InvalidDataException(
+                $"Unsupported platform '{value}' for application '{applicationId}'.")
+        };
+
+    private static PlatformSupportStatus ParsePlatformSupport(string? value, string applicationId) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            "supported" => PlatformSupportStatus.Supported,
+            "planned" => PlatformSupportStatus.Planned,
+            "unsupported" => PlatformSupportStatus.Unsupported,
+            _ => throw new InvalidDataException(
+                $"Unsupported platform support status '{value}' for application '{applicationId}'.")
+        };
+
+    private static PackageScope ParseScope(string? value, string applicationId) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            null or "" or "any" or "default" => PackageScope.Default,
+            "user" => PackageScope.User,
+            "machine" => PackageScope.Machine,
+            _ => throw new InvalidDataException(
+                $"Unsupported package scope '{value}' for application '{applicationId}'.")
+        };
+
+    private static void ValidatePackageId(string packageId, string applicationId)
+    {
+        if (packageId[0] is '-' or '/' || packageId.Any(character =>
+                !(char.IsLetterOrDigit(character) || character is '.' or '-' or '_')))
+        {
+            throw new InvalidDataException(
+                $"Unsafe package id '{packageId}' for application '{applicationId}'.");
+        }
+    }
+
+    private static string RequireText(string? value, string field)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidDataException($"Required catalogue field '{field}' is missing.");
+        }
+
+        return value.Trim();
+    }
+
+    private sealed class CatalogueDocumentDto
+    {
+        public string? SchemaVersion { get; init; }
+        public string? CatalogueVersion { get; init; }
+        public List<ApplicationDto>? Applications { get; init; }
+    }
+
+    private sealed class ApplicationDto
+    {
+        public string? Id { get; init; }
+        public string? Name { get; init; }
+        public string? Publisher { get; init; }
+        public string? Description { get; init; }
+        public LifecycleDto? Lifecycle { get; init; }
+        public List<RecommendationDto>? Recommendations { get; init; }
+        public RequirementsDto? Requirements { get; init; }
+        public List<PlatformSupportDto>? PlatformSupport { get; init; }
+        public List<ProviderDto>? Providers { get; init; }
+        public List<string>? RegistryDisplayNames { get; init; }
+        public List<string>? Dependencies { get; init; }
+        public List<string>? Conflicts { get; init; }
+    }
+
+    private sealed class LifecycleDto
+    {
+        public string? Status { get; init; }
+    }
+
+    private sealed class RecommendationDto
+    {
+        public string? Profile { get; init; }
+        public string? Level { get; init; }
+        public string? ReasonKey { get; init; }
+    }
+
+    private sealed class RequirementsDto
+    {
+        public CapabilityRequirementsDto? Minimum { get; init; }
+        public CapabilityRequirementsDto? Recommended { get; init; }
+    }
+
+    private sealed class CapabilityRequirementsDto
+    {
+        public long? MinRamMiB { get; init; }
+        public long? MinFreeStorageMiB { get; init; }
+        public bool GpuRequired { get; init; }
+        public List<string>? Architectures { get; init; }
+    }
+
+    private sealed class PlatformSupportDto
+    {
+        public string? Platform { get; init; }
+        public string? Status { get; init; }
+        public List<string>? Architectures { get; init; }
+    }
+
+    private sealed class ProviderDto
+    {
+        public string? Platform { get; init; }
+        public string? Type { get; init; }
+        public string? PackageId { get; init; }
+        public string? Source { get; init; }
+        public string? ScopePreference { get; init; }
+    }
+}

--- a/tests/AgenStart.Catalogue.Tests/AgenStart.Catalogue.Tests.csproj
+++ b/tests/AgenStart.Catalogue.Tests/AgenStart.Catalogue.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgenStart.Catalogue\AgenStart.Catalogue.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\docs\product\catalogue.fixtures.json"
+          Link="Fixtures\catalogue.fixtures.json"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/AgenStart.Catalogue.Tests/SoftwareCatalogueLoaderTests.cs
+++ b/tests/AgenStart.Catalogue.Tests/SoftwareCatalogueLoaderTests.cs
@@ -1,0 +1,90 @@
+using System.Text.Json.Nodes;
+using AgenStart.PackageManagement;
+using Xunit;
+
+namespace AgenStart.Catalogue.Tests;
+
+public sealed class SoftwareCatalogueLoaderTests
+{
+    [Fact]
+    public void Load_real_fixture_maps_runtime_catalogue()
+    {
+        var catalogue = LoadFixture();
+
+        Assert.Equal("1.0.0", catalogue.SchemaVersion);
+        Assert.Equal(8, catalogue.Applications.Count);
+
+        var git = Assert.Single(catalogue.Applications, application => application.Id == "git");
+        Assert.Equal("Git Project", git.Publisher);
+        Assert.NotNull(git.WindowsPackage);
+        Assert.Equal(PackageProviderIds.WinGet, git.WindowsPackage.ProviderId);
+        Assert.Equal("Git.Git", git.WindowsPackage.PackageId);
+        Assert.Equal("winget", git.WindowsPackage.Source);
+    }
+
+    [Fact]
+    public void Load_builds_detection_targets_from_same_canonical_identity()
+    {
+        var catalogue = LoadFixture();
+        var applications = catalogue.Applications.ToDictionary(application => application.Id, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var target in catalogue.DetectionTargets)
+        {
+            var application = applications[target.ApplicationId];
+            Assert.Equal(application.Name, target.DisplayName);
+            Assert.Equal(application.Publisher, target.Publisher);
+            Assert.Equal(application.ProviderPackages, target.ProviderPackages);
+        }
+    }
+
+    [Fact]
+    public void Load_rejects_duplicate_application_ids()
+    {
+        var document = LoadFixtureNode();
+        var applications = document["applications"]!.AsArray();
+        applications.Add(JsonNode.Parse(applications[0]!.ToJsonString()));
+
+        var exception = Assert.Throws<InvalidDataException>(() =>
+            new SoftwareCatalogueLoader().Load(document.ToJsonString()));
+
+        Assert.Contains("Duplicate catalogue application id", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_rejects_untrusted_winget_source()
+    {
+        var document = LoadFixtureNode();
+        var firstApplication = document["applications"]!.AsArray()[0]!.AsObject();
+        firstApplication["providers"]!.AsArray()[0]!["source"] = "random-mirror";
+
+        var exception = Assert.Throws<InvalidDataException>(() =>
+            new SoftwareCatalogueLoader().Load(document.ToJsonString()));
+
+        Assert.Contains("Untrusted WinGet source", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_rejects_unknown_architecture()
+    {
+        var document = LoadFixtureNode();
+        var firstApplication = document["applications"]!.AsArray()[0]!.AsObject();
+        firstApplication["requirements"]!["minimum"]!["architectures"]![0] = "mips";
+
+        var exception = Assert.Throws<InvalidDataException>(() =>
+            new SoftwareCatalogueLoader().Load(document.ToJsonString()));
+
+        Assert.Contains("Unsupported architecture", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static SoftwareCatalogue LoadFixture()
+    {
+        using var stream = File.OpenRead(FixturePath());
+        return new SoftwareCatalogueLoader().Load(stream);
+    }
+
+    private static JsonObject LoadFixtureNode() =>
+        JsonNode.Parse(File.ReadAllText(FixturePath()))!.AsObject();
+
+    private static string FixturePath() =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "catalogue.fixtures.json");
+}


### PR DESCRIPTION
## Summary

Implements the runtime catalogue boundary required to connect the desktop flow to the existing software-detection and recommendation engines.

### Runtime catalogue
- adds `AgenStart.Catalogue`
- parses the checked-in V1 JSON catalogue with `System.Text.Json`
- maps each canonical application into `ApplicationDefinition`
- derives `SoftwareDetectionTarget` values from the same application identity
- maps trusted Windows provider metadata into exact `ProviderPackageReference` values
- exposes publisher and description metadata for the future desktop recommendations view

### Fail-closed validation
- requires schema version `1.0.0`
- rejects duplicate application IDs
- rejects unknown profiles, lifecycle states, platform states and architectures
- rejects active Windows applications without a trusted WinGet mapping
- accepts only `winget` and `msstore` as Windows sources
- rejects unsafe package-id characters
- does not introduce catalogue-provided shell commands

### Verification
- tests against the real catalogue fixture
- verifies canonical detection identity and exact Git WinGet mapping
- covers duplicate IDs, untrusted sources and unsupported architectures
- adds a dedicated catalogue CI gate

Closes #31
Unblocks the Usage profile → Recommendations slice of #8.