### PR TITLE
feat: wire review installation and report desktop flow

### DIFF
--- a/src/AgenStart.Desktop/AgenStart.Desktop.csproj
+++ b/src/AgenStart.Desktop/AgenStart.Desktop.csproj
@@ -16,8 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AgenStart.Application\AgenStart.Application.csproj" />
     <ProjectReference Include="..\AgenStart.Catalogue\AgenStart.Catalogue.csproj" />
     <ProjectReference Include="..\AgenStart.Core\AgenStart.Core.csproj" />
+    <ProjectReference Include="..\AgenStart.PackageManagement\AgenStart.PackageManagement.csproj" />
     <ProjectReference Include="..\AgenStart.Platform.Windows\AgenStart.Platform.Windows.csproj" />
     <ProjectReference Include="..\AgenStart.Recommendations\AgenStart.Recommendations.csproj" />
     <ProjectReference Include="..\AgenStart.SoftwareInventory\AgenStart.SoftwareInventory.csproj" />

--- a/src/AgenStart.Desktop/App.axaml.cs
+++ b/src/AgenStart.Desktop/App.axaml.cs
@@ -5,7 +5,7 @@ using AgenStart.Desktop.Views;
 
 namespace AgenStart.Desktop;
 
-public sealed partial class App : Application
+public sealed partial class App : Avalonia.Application
 {
     public override void Initialize() => AvaloniaXamlLoader.Load(this);
 

--- a/src/AgenStart.Desktop/ViewModels/InstallationFlowRows.cs
+++ b/src/AgenStart.Desktop/ViewModels/InstallationFlowRows.cs
@@ -1,0 +1,158 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using AgenStart.Application.Installation;
+
+namespace AgenStart.Desktop.ViewModels;
+
+public sealed class ReviewRowViewModel
+{
+    public ReviewRowViewModel(
+        string applicationId,
+        string name,
+        string initials,
+        string reason,
+        bool willInstall,
+        bool alreadyInstalled)
+    {
+        ApplicationId = applicationId;
+        Name = name;
+        Initials = initials;
+        Reason = reason;
+        WillInstall = willInstall;
+        AlreadyInstalled = alreadyInstalled;
+    }
+
+    public string ApplicationId { get; }
+    public string Name { get; }
+    public string Initials { get; }
+    public string Reason { get; }
+    public bool WillInstall { get; }
+    public bool AlreadyInstalled { get; }
+    public bool CanRemove => WillInstall;
+    public string Status => AlreadyInstalled ? "Already installed" : "Will install";
+}
+
+public sealed class InstallationRowViewModel : INotifyPropertyChanged
+{
+    private InstallationQueueItemState _state;
+    private string _status = "Waiting";
+    private string? _message;
+    private bool _canRetry;
+    private string? _installedVersion;
+    private bool _requiresReboot;
+
+    public InstallationRowViewModel(string applicationId, string name, string initials)
+    {
+        ApplicationId = applicationId;
+        Name = name;
+        Initials = initials;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string ApplicationId { get; }
+    public string Name { get; }
+    public string Initials { get; }
+
+    public InstallationQueueItemState State
+    {
+        get => _state;
+        private set => SetField(ref _state, value);
+    }
+
+    public string Status
+    {
+        get => _status;
+        private set => SetField(ref _status, value);
+    }
+
+    public string? Message
+    {
+        get => _message;
+        private set => SetField(ref _message, value);
+    }
+
+    public bool CanRetry
+    {
+        get => _canRetry;
+        private set => SetField(ref _canRetry, value);
+    }
+
+    public string? InstalledVersion
+    {
+        get => _installedVersion;
+        private set => SetField(ref _installedVersion, value);
+    }
+
+    public bool RequiresReboot
+    {
+        get => _requiresReboot;
+        private set => SetField(ref _requiresReboot, value);
+    }
+
+    public bool IsRunning => State == InstallationQueueItemState.Running;
+    public bool HasFailure => State == InstallationQueueItemState.Failed;
+
+    public void Apply(InstallationItemSnapshot snapshot)
+    {
+        State = snapshot.State;
+        Status = snapshot.State switch
+        {
+            InstallationQueueItemState.Queued => "Waiting",
+            InstallationQueueItemState.Running => "Installing",
+            InstallationQueueItemState.Succeeded when snapshot.LastOperationStatus == PackageManagement.PackageOperationStatus.AlreadyInstalled => "Already installed",
+            InstallationQueueItemState.Succeeded => snapshot.RequiresReboot ? "Installed · restart required" : "Installed",
+            InstallationQueueItemState.Failed => "Failed",
+            InstallationQueueItemState.Skipped => "Skipped",
+            InstallationQueueItemState.Cancelled => "Cancelled",
+            _ => snapshot.State.ToString()
+        };
+        Message = snapshot.Message;
+        CanRetry = snapshot.CanRetry;
+        InstalledVersion = snapshot.InstalledVersion;
+        RequiresReboot = snapshot.RequiresReboot;
+        OnPropertyChanged(nameof(IsRunning));
+        OnPropertyChanged(nameof(HasFailure));
+    }
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+
+public sealed class ReportRowViewModel
+{
+    public ReportRowViewModel(
+        string applicationId,
+        string name,
+        string initials,
+        string result,
+        string? installedVersion,
+        bool requiresReboot)
+    {
+        ApplicationId = applicationId;
+        Name = name;
+        Initials = initials;
+        Result = result;
+        InstalledVersion = installedVersion ?? "—";
+        RequiresReboot = requiresReboot;
+    }
+
+    public string ApplicationId { get; }
+    public string Name { get; }
+    public string Initials { get; }
+    public string Result { get; }
+    public string InstalledVersion { get; }
+    public bool RequiresReboot { get; }
+}

--- a/src/AgenStart.Desktop/ViewModels/InstallationFlowRows.cs
+++ b/src/AgenStart.Desktop/ViewModels/InstallationFlowRows.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using AgenStart.Application.Installation;
+using AgenStart.PackageManagement;
 
 namespace AgenStart.Desktop.ViewModels;
 
@@ -100,7 +101,7 @@ public sealed class InstallationRowViewModel : INotifyPropertyChanged
         {
             InstallationQueueItemState.Queued => "Waiting",
             InstallationQueueItemState.Running => "Installing",
-            InstallationQueueItemState.Succeeded when snapshot.LastOperationStatus == PackageManagement.PackageOperationStatus.AlreadyInstalled => "Already installed",
+            InstallationQueueItemState.Succeeded when snapshot.LastOperationStatus == PackageOperationStatus.AlreadyInstalled => "Already installed",
             InstallationQueueItemState.Succeeded => snapshot.RequiresReboot ? "Installed · restart required" : "Installed",
             InstallationQueueItemState.Failed => "Failed",
             InstallationQueueItemState.Skipped => "Skipped",

--- a/src/AgenStart.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/src/AgenStart.Desktop/ViewModels/MainWindowViewModel.cs
@@ -2,17 +2,21 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using Avalonia.Threading;
+using AgenStart.Application.Installation;
 using AgenStart.Catalogue;
 using AgenStart.Core.Catalogue;
 using AgenStart.Core.Machine;
+using AgenStart.PackageManagement;
 using AgenStart.Platform.Windows.Inventory;
 using AgenStart.Platform.Windows.SoftwareInventory;
+using AgenStart.Platform.Windows.WinGet;
 using AgenStart.Recommendations;
 using AgenStart.SoftwareInventory;
 
 namespace AgenStart.Desktop.ViewModels;
 
-public sealed class MainWindowViewModel : INotifyPropertyChanged
+public sealed class MainWindowViewModel : INotifyPropertyChanged, IDisposable
 {
     private readonly IMachineInventoryProvider _machineInventory;
     private readonly IInstalledSoftwareInventoryProvider _softwareInventory;
@@ -21,11 +25,26 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly SoftwareCatalogueLoader _catalogueLoader;
 
     private MachineSnapshot? _machineSnapshot;
+    private SoftwareCatalogue? _catalogue;
+    private InstallationOrchestrator? _installationOrchestrator;
+    private InstallationSession? _installationSession;
+    private InstallationReport? _installationReport;
+    private bool _disposed;
+
     private bool _isBusy;
     private bool _hasSnapshot;
     private bool _hasRecommendations;
+    private bool _hasReview;
+    private bool _isInstalling;
+    private bool _hasReport;
+    private bool _agreementsAccepted;
     private UserProfile _selectedProfile = UserProfile.Development;
+
     private string _recommendationStatus = "Choose a usage profile to build recommendations.";
+    private string _installationStatus = "Ready to install the approved setup.";
+    private string _currentInstallationName = "Waiting to start";
+    private string _reportStatus = "No installation report yet.";
+    private string _reportCompletedAt = "—";
     private string _statusTitle = "Ready for analysis";
     private string _statusMessage = "AgenStart can inspect the essential capabilities of this PC locally.";
     private string _operatingSystem = "Not analysed";
@@ -56,6 +75,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public ObservableCollection<RecommendationRowViewModel> Recommendations { get; } = [];
+    public ObservableCollection<ReviewRowViewModel> ReviewItems { get; } = [];
+    public ObservableCollection<InstallationRowViewModel> InstallationItems { get; } = [];
+    public ObservableCollection<ReportRowViewModel> ReportItems { get; } = [];
 
     public bool IsBusy
     {
@@ -73,6 +95,42 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         get => _hasRecommendations;
         private set => SetField(ref _hasRecommendations, value);
+    }
+
+    public bool HasReview
+    {
+        get => _hasReview;
+        private set => SetField(ref _hasReview, value);
+    }
+
+    public bool IsInstalling
+    {
+        get => _isInstalling;
+        private set
+        {
+            if (SetField(ref _isInstalling, value))
+            {
+                OnPropertyChanged(nameof(CanStartInstallation));
+            }
+        }
+    }
+
+    public bool HasReport
+    {
+        get => _hasReport;
+        private set => SetField(ref _hasReport, value);
+    }
+
+    public bool AgreementsAccepted
+    {
+        get => _agreementsAccepted;
+        set
+        {
+            if (SetField(ref _agreementsAccepted, value))
+            {
+                OnPropertyChanged(nameof(CanStartInstallation));
+            }
+        }
     }
 
     public UserProfile SelectedProfile
@@ -108,10 +166,53 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         private set => SetField(ref _recommendationStatus, value);
     }
 
+    public string InstallationStatus
+    {
+        get => _installationStatus;
+        private set => SetField(ref _installationStatus, value);
+    }
+
+    public string CurrentInstallationName
+    {
+        get => _currentInstallationName;
+        private set => SetField(ref _currentInstallationName, value);
+    }
+
+    public string ReportStatus
+    {
+        get => _reportStatus;
+        private set => SetField(ref _reportStatus, value);
+    }
+
+    public string ReportCompletedAt
+    {
+        get => _reportCompletedAt;
+        private set => SetField(ref _reportCompletedAt, value);
+    }
+
     public int RecommendationCount => Recommendations.Count;
     public int SelectedCount => Recommendations.Count(row => row.IsSelected);
     public int AlreadyInstalledCount => Recommendations.Count(row => row.Disposition == RecommendationDisposition.AlreadyInstalled);
     public int OptionalCount => Recommendations.Count(row => row.Level == RecommendationLevel.Optional && row.Disposition == RecommendationDisposition.Recommended);
+    public bool CanReview => HasRecommendations && SelectedCount > 0 && !IsInstalling;
+
+    public int ReviewInstallCount => ReviewItems.Count(row => row.WillInstall);
+    public int ReviewAlreadyInstalledCount => ReviewItems.Count(row => row.AlreadyInstalled);
+    public int ReviewTotalCount => ReviewItems.Count;
+    public bool CanStartInstallation => HasReview && ReviewInstallCount > 0 && AgreementsAccepted && !IsInstalling;
+
+    public int InstallationCompletedCount => InstallationItems.Count(row => row.State == InstallationQueueItemState.Succeeded);
+    public int InstallationFailedCount => InstallationItems.Count(row => row.State == InstallationQueueItemState.Failed);
+    public int InstallationRemainingCount => InstallationItems.Count(row => row.State is InstallationQueueItemState.Queued or InstallationQueueItemState.Running);
+    public int InstallationTotalCount => InstallationItems.Count;
+
+    public int ReportProcessedCount => ReportItems.Count;
+    public int ReportInstalledCount => _installationReport?.Items.Count(item =>
+        item.State == InstallationQueueItemState.Succeeded &&
+        item.LastOperationStatus != PackageOperationStatus.AlreadyInstalled) ?? 0;
+    public int ReportAlreadyInstalledCount => ReportItems.Count(row => row.Result == "Already installed");
+    public int ReportFailedCount => _installationReport?.FailedCount ?? 0;
+    public bool ReportRequiresReboot => _installationReport?.Items.Any(item => item.RequiresReboot) == true;
 
     public string StatusTitle
     {
@@ -187,7 +288,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public void SelectProfile(UserProfile profile)
     {
-        if (SelectedProfile == profile)
+        if (SelectedProfile == profile || IsInstalling)
         {
             return;
         }
@@ -199,7 +300,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public async Task AnalyzeAsync(CancellationToken cancellationToken = default)
     {
-        if (IsBusy)
+        if (IsBusy || IsInstalling)
         {
             return;
         }
@@ -232,7 +333,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public async Task BuildRecommendationsAsync(CancellationToken cancellationToken = default)
     {
-        if (IsBusy || _machineSnapshot is null)
+        if (IsBusy || IsInstalling || _machineSnapshot is null)
         {
             return;
         }
@@ -257,6 +358,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 catalogue.Definitions));
 
             ClearRecommendations();
+            _catalogue = catalogue;
             var metadata = catalogue.Applications.ToDictionary(
                 application => application.Id,
                 StringComparer.OrdinalIgnoreCase);
@@ -292,6 +394,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public void SelectEssentialsOnly()
     {
+        if (IsInstalling)
+        {
+            return;
+        }
+
         foreach (var row in Recommendations.Where(row => row.CanSelect))
         {
             row.IsSelected = row.Level == RecommendationLevel.Essential;
@@ -300,11 +407,306 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RaiseRecommendationSummary();
     }
 
+    public bool PrepareReview()
+    {
+        if (!CanReview || _catalogue is null)
+        {
+            return false;
+        }
+
+        ResetInstallationFlow();
+        ReviewItems.Clear();
+
+        foreach (var row in Recommendations.Where(row =>
+                     row.IsSelected || row.Disposition == RecommendationDisposition.AlreadyInstalled))
+        {
+            ReviewItems.Add(new ReviewRowViewModel(
+                row.ApplicationId,
+                row.Name,
+                row.Initials,
+                row.Reason,
+                row.IsSelected,
+                row.Disposition == RecommendationDisposition.AlreadyInstalled));
+        }
+
+        HasReview = ReviewItems.Any(row => row.WillInstall);
+        AgreementsAccepted = false;
+        RaiseReviewSummary();
+        return HasReview;
+    }
+
+    public void RemoveFromReview(string applicationId)
+    {
+        if (IsInstalling || string.IsNullOrWhiteSpace(applicationId))
+        {
+            return;
+        }
+
+        var recommendation = Recommendations.FirstOrDefault(row =>
+            string.Equals(row.ApplicationId, applicationId, StringComparison.OrdinalIgnoreCase));
+        if (recommendation is { CanSelect: true })
+        {
+            recommendation.IsSelected = false;
+        }
+
+        PrepareReview();
+    }
+
+    public async Task<bool> StartInstallationAsync(CancellationToken cancellationToken = default)
+    {
+        if (!CanStartInstallation || _catalogue is null)
+        {
+            return false;
+        }
+
+        var selectedRows = Recommendations.Where(row => row.IsSelected).ToArray();
+        var catalogueById = _catalogue.Applications.ToDictionary(
+            application => application.Id,
+            StringComparer.OrdinalIgnoreCase);
+        var selections = new List<InstallationSelection>(selectedRows.Length);
+
+        foreach (var row in selectedRows)
+        {
+            if (!catalogueById.TryGetValue(row.ApplicationId, out var application) || application.WindowsPackage is null)
+            {
+                InstallationStatus = $"{row.Name} has no trusted Windows package mapping and cannot be installed.";
+                return false;
+            }
+
+            selections.Add(new InstallationSelection(
+                row.ApplicationId,
+                application.WindowsPackage,
+                Approved: true,
+                Silent: true,
+                AcceptPackageAgreements: AgreementsAccepted,
+                AcceptSourceAgreements: AgreementsAccepted));
+        }
+
+        if (selections.Count == 0)
+        {
+            return false;
+        }
+
+        DisposeInstallationSession();
+        InstallationItems.Clear();
+        ReportItems.Clear();
+        _installationReport = null;
+        HasReport = false;
+
+        var verifier = new SoftwareInventoryInstallationVerifier(
+            _softwareInventory,
+            _catalogue.DetectionTargets,
+            _softwareStateResolver);
+        _installationOrchestrator = new InstallationOrchestrator(
+            [new WinGetProvider()],
+            verifier);
+        _installationSession = _installationOrchestrator.CreateSession(selections);
+        _installationSession.ProgressChanged += InstallationSession_OnProgressChanged;
+
+        foreach (var item in _installationSession.Items)
+        {
+            var application = catalogueById[item.ApplicationId];
+            var row = new InstallationRowViewModel(
+                item.ApplicationId,
+                application.Name,
+                BuildInitials(application.Name));
+            row.Apply(item);
+            InstallationItems.Add(row);
+        }
+
+        IsInstalling = true;
+        InstallationStatus = "AgenStart is installing only the applications you approved.";
+        CurrentInstallationName = "Preparing installation queue";
+        RaiseInstallationSummary();
+
+        try
+        {
+            var report = await _installationOrchestrator
+                .RunAsync(_installationSession, cancellationToken)
+                .ConfigureAwait(true);
+            ApplyInstallationReport(report);
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            InstallationStatus = "Installation cancelled.";
+            if (_installationSession is not null)
+            {
+                ApplyInstallationReport(_installationSession.CreateReport());
+            }
+            return false;
+        }
+        finally
+        {
+            IsInstalling = false;
+            RaiseInstallationSummary();
+        }
+    }
+
+    public void CancelInstallation()
+    {
+        if (!IsInstalling)
+        {
+            return;
+        }
+
+        InstallationStatus = "Cancelling safely after the current provider operation…";
+        _installationSession?.Cancel();
+    }
+
+    public async Task<bool> RetryInstallationAsync(
+        string applicationId,
+        CancellationToken cancellationToken = default)
+    {
+        if (IsInstalling || _installationOrchestrator is null || _installationSession is null)
+        {
+            return false;
+        }
+
+        var row = InstallationItems.FirstOrDefault(item =>
+            string.Equals(item.ApplicationId, applicationId, StringComparison.OrdinalIgnoreCase));
+        if (row is not { CanRetry: true })
+        {
+            return false;
+        }
+
+        IsInstalling = true;
+        InstallationStatus = $"Retrying {row.Name}.";
+        CurrentInstallationName = row.Name;
+
+        try
+        {
+            var report = await _installationOrchestrator
+                .RetryAsync(_installationSession, applicationId, cancellationToken)
+                .ConfigureAwait(true);
+            ApplyInstallationReport(report);
+            return true;
+        }
+        finally
+        {
+            IsInstalling = false;
+            RaiseInstallationSummary();
+        }
+    }
+
     private void RecommendationRow_OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(RecommendationRowViewModel.IsSelected))
         {
-            OnPropertyChanged(nameof(SelectedCount));
+            RaiseRecommendationSummary();
+            ResetReviewOnly();
+        }
+    }
+
+    private void InstallationSession_OnProgressChanged(object? sender, InstallationProgressEvent e)
+    {
+        Dispatcher.UIThread.Post(() => ApplyInstallationProgress(e));
+    }
+
+    private void ApplyInstallationProgress(InstallationProgressEvent progress)
+    {
+        if (progress.Item is not null)
+        {
+            var row = InstallationItems.FirstOrDefault(item =>
+                string.Equals(item.ApplicationId, progress.Item.ApplicationId, StringComparison.OrdinalIgnoreCase));
+            row?.Apply(progress.Item);
+            if (progress.Item.State == InstallationQueueItemState.Running)
+            {
+                CurrentInstallationName = row?.Name ?? progress.Item.ApplicationId;
+            }
+        }
+
+        InstallationStatus = progress.Code switch
+        {
+            "session.started" => "Installation started. Packages are resolved through trusted provider identities.",
+            "session.completed" => "Installation queue completed.",
+            "session.cancelled" => "Installation queue cancelled.",
+            "session.cancellation-requested" => "Cancellation requested. Waiting for the provider operation to stop safely.",
+            _ => progress.Message
+        };
+        RaiseInstallationSummary();
+    }
+
+    private void ApplyInstallationReport(InstallationReport report)
+    {
+        _installationReport = report;
+
+        foreach (var snapshot in report.Items)
+        {
+            var row = InstallationItems.FirstOrDefault(item =>
+                string.Equals(item.ApplicationId, snapshot.ApplicationId, StringComparison.OrdinalIgnoreCase));
+            row?.Apply(snapshot);
+        }
+
+        BuildReportRows(report);
+        HasReport = true;
+        InstallationStatus = report.State == InstallationSessionState.Cancelled
+            ? "Installation cancelled. Review the final state below."
+            : report.FailedCount > 0
+                ? "Installation completed with issues. Failed items can be retried when available."
+                : "Installation completed successfully.";
+        CurrentInstallationName = "Queue complete";
+        ReportStatus = report.State == InstallationSessionState.Cancelled
+            ? "The approved setup was cancelled before every item completed."
+            : report.FailedCount > 0
+                ? "AgenStart finished the approved setup with issues."
+                : "AgenStart finished the approved setup.";
+        ReportCompletedAt = report.CompletedAtUtc?.ToLocalTime().ToString("g", CultureInfo.CurrentCulture) ?? "—";
+        RaiseInstallationSummary();
+        RaiseReportSummary();
+    }
+
+    private void BuildReportRows(InstallationReport report)
+    {
+        ReportItems.Clear();
+        if (_catalogue is null)
+        {
+            return;
+        }
+
+        var catalogueById = _catalogue.Applications.ToDictionary(
+            application => application.Id,
+            StringComparer.OrdinalIgnoreCase);
+        var included = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var item in report.Items.OrderBy(item => item.Sequence))
+        {
+            if (!catalogueById.TryGetValue(item.ApplicationId, out var application))
+            {
+                continue;
+            }
+
+            var result = item.State switch
+            {
+                InstallationQueueItemState.Succeeded when item.LastOperationStatus == PackageOperationStatus.AlreadyInstalled => "Already installed",
+                InstallationQueueItemState.Succeeded => "Installed",
+                InstallationQueueItemState.Failed => "Failed",
+                InstallationQueueItemState.Skipped => "Skipped",
+                InstallationQueueItemState.Cancelled => "Cancelled",
+                _ => item.State.ToString()
+            };
+
+            ReportItems.Add(new ReportRowViewModel(
+                item.ApplicationId,
+                application.Name,
+                BuildInitials(application.Name),
+                result,
+                item.InstalledVersion,
+                item.RequiresReboot));
+            included.Add(item.ApplicationId);
+        }
+
+        foreach (var recommendation in Recommendations.Where(row =>
+                     row.Disposition == RecommendationDisposition.AlreadyInstalled &&
+                     !included.Contains(row.ApplicationId)))
+        {
+            ReportItems.Add(new ReportRowViewModel(
+                recommendation.ApplicationId,
+                recommendation.Name,
+                recommendation.Initials,
+                "Already installed",
+                null,
+                requiresReboot: false));
         }
     }
 
@@ -316,8 +718,57 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         Recommendations.Clear();
+        _catalogue = null;
         HasRecommendations = false;
+        ResetInstallationFlow();
         RaiseRecommendationSummary();
+    }
+
+    private void ResetReviewOnly()
+    {
+        if (IsInstalling)
+        {
+            return;
+        }
+
+        ReviewItems.Clear();
+        HasReview = false;
+        AgreementsAccepted = false;
+        RaiseReviewSummary();
+    }
+
+    private void ResetInstallationFlow()
+    {
+        if (IsInstalling)
+        {
+            return;
+        }
+
+        ResetReviewOnly();
+        DisposeInstallationSession();
+        InstallationItems.Clear();
+        ReportItems.Clear();
+        _installationReport = null;
+        HasReport = false;
+        InstallationStatus = "Ready to install the approved setup.";
+        CurrentInstallationName = "Waiting to start";
+        ReportStatus = "No installation report yet.";
+        ReportCompletedAt = "—";
+        RaiseInstallationSummary();
+        RaiseReportSummary();
+    }
+
+    private void DisposeInstallationSession()
+    {
+        if (_installationSession is null)
+        {
+            return;
+        }
+
+        _installationSession.ProgressChanged -= InstallationSession_OnProgressChanged;
+        _installationSession.Dispose();
+        _installationSession = null;
+        _installationOrchestrator = null;
     }
 
     private void RaiseRecommendationSummary()
@@ -326,6 +777,32 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(SelectedCount));
         OnPropertyChanged(nameof(AlreadyInstalledCount));
         OnPropertyChanged(nameof(OptionalCount));
+        OnPropertyChanged(nameof(CanReview));
+    }
+
+    private void RaiseReviewSummary()
+    {
+        OnPropertyChanged(nameof(ReviewInstallCount));
+        OnPropertyChanged(nameof(ReviewAlreadyInstalledCount));
+        OnPropertyChanged(nameof(ReviewTotalCount));
+        OnPropertyChanged(nameof(CanStartInstallation));
+    }
+
+    private void RaiseInstallationSummary()
+    {
+        OnPropertyChanged(nameof(InstallationCompletedCount));
+        OnPropertyChanged(nameof(InstallationFailedCount));
+        OnPropertyChanged(nameof(InstallationRemainingCount));
+        OnPropertyChanged(nameof(InstallationTotalCount));
+    }
+
+    private void RaiseReportSummary()
+    {
+        OnPropertyChanged(nameof(ReportProcessedCount));
+        OnPropertyChanged(nameof(ReportInstalledCount));
+        OnPropertyChanged(nameof(ReportAlreadyInstalledCount));
+        OnPropertyChanged(nameof(ReportFailedCount));
+        OnPropertyChanged(nameof(ReportRequiresReboot));
     }
 
     private void ApplySnapshot(MachineSnapshot snapshot)
@@ -405,6 +882,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return $"{Math.Round(bytes / gib):0} GB";
     }
 
+    private static string BuildInitials(string name)
+    {
+        var words = name
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Take(2)
+            .ToArray();
+
+        return words.Length switch
+        {
+            0 => "•",
+            1 => words[0][..1].ToUpperInvariant(),
+            _ => string.Concat(words.Select(word => char.ToUpperInvariant(word[0])))
+        };
+    }
+
     private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
         if (EqualityComparer<T>.Default.Equals(field, value))
@@ -419,4 +911,20 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        if (IsInstalling)
+        {
+            _installationSession?.Cancel();
+        }
+
+        DisposeInstallationSession();
+    }
 }

--- a/src/AgenStart.Desktop/Views/MainWindow.axaml
+++ b/src/AgenStart.Desktop/Views/MainWindow.axaml
@@ -22,37 +22,32 @@
         <StackPanel Grid.Row="1" Spacing="1">
           <Grid>
             <Border x:Name="OverviewStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" />
-            <Button x:Name="OverviewButton" Classes="nav active" Click="OverviewButton_OnClick">
-              <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="⌂" FontSize="22" Width="24" TextAlignment="Center" /><TextBlock Text="Overview" VerticalAlignment="Center" /></StackPanel>
-            </Button>
+            <Button x:Name="OverviewButton" Classes="nav active" Click="OverviewButton_OnClick"><StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="⌂" FontSize="22" Width="24" TextAlignment="Center" /><TextBlock Text="Overview" VerticalAlignment="Center" /></StackPanel></Button>
           </Grid>
           <Grid>
             <Border x:Name="YourPcStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" IsVisible="False" />
-            <Button x:Name="YourPcButton" Classes="nav" Click="YourPcButton_OnClick">
-              <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="▣" FontSize="18" Width="24" TextAlignment="Center" /><TextBlock Text="Your PC" VerticalAlignment="Center" /></StackPanel>
-            </Button>
+            <Button x:Name="YourPcButton" Classes="nav" Click="YourPcButton_OnClick"><StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="▣" FontSize="18" Width="24" TextAlignment="Center" /><TextBlock Text="Your PC" VerticalAlignment="Center" /></StackPanel></Button>
           </Grid>
           <Grid>
             <Border x:Name="UsageProfileStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" IsVisible="False" />
-            <Button x:Name="UsageProfileButton" Classes="nav" Click="UsageProfileButton_OnClick">
-              <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="○" FontSize="21" Width="24" TextAlignment="Center" /><TextBlock Text="Usage profile" VerticalAlignment="Center" /></StackPanel>
-            </Button>
+            <Button x:Name="UsageProfileButton" Classes="nav" Click="UsageProfileButton_OnClick"><StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="○" FontSize="21" Width="24" TextAlignment="Center" /><TextBlock Text="Usage profile" VerticalAlignment="Center" /></StackPanel></Button>
           </Grid>
           <Grid>
             <Border x:Name="RecommendationsStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" IsVisible="False" />
-            <Button x:Name="RecommendationsButton" Classes="nav" Click="RecommendationsButton_OnClick">
-              <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="✦" FontSize="20" Width="24" TextAlignment="Center" /><TextBlock Text="Recommendations" VerticalAlignment="Center" /></StackPanel>
-            </Button>
+            <Button x:Name="RecommendationsButton" Classes="nav" Click="RecommendationsButton_OnClick"><StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="✦" FontSize="20" Width="24" TextAlignment="Center" /><TextBlock Text="Recommendations" VerticalAlignment="Center" /></StackPanel></Button>
           </Grid>
-          <Button Classes="nav" IsEnabled="False">
-            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="✓" FontSize="20" Width="24" TextAlignment="Center" /><TextBlock Text="Review" VerticalAlignment="Center" /></StackPanel>
-          </Button>
-          <Button Classes="nav" IsEnabled="False">
-            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="↓" FontSize="21" Width="24" TextAlignment="Center" /><TextBlock Text="Installation" VerticalAlignment="Center" /></StackPanel>
-          </Button>
-          <Button Classes="nav" IsEnabled="False">
-            <StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="▤" FontSize="18" Width="24" TextAlignment="Center" /><TextBlock Text="Report" VerticalAlignment="Center" /></StackPanel>
-          </Button>
+          <Grid>
+            <Border x:Name="ReviewStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" IsVisible="False" />
+            <Button x:Name="ReviewButton" Classes="nav" Click="ReviewButton_OnClick"><StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="✓" FontSize="20" Width="24" TextAlignment="Center" /><TextBlock Text="Review" VerticalAlignment="Center" /></StackPanel></Button>
+          </Grid>
+          <Grid>
+            <Border x:Name="InstallationStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" IsVisible="False" />
+            <Button x:Name="InstallationButton" Classes="nav" Click="InstallationButton_OnClick"><StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="↓" FontSize="21" Width="24" TextAlignment="Center" /><TextBlock Text="Installation" VerticalAlignment="Center" /></StackPanel></Button>
+          </Grid>
+          <Grid>
+            <Border x:Name="ReportStripe" Width="3" Height="42" Background="{StaticResource AgenAccentBrush}" HorizontalAlignment="Left" CornerRadius="0,3,3,0" IsVisible="False" />
+            <Button x:Name="ReportButton" Classes="nav" Click="ReportButton_OnClick"><StackPanel Orientation="Horizontal" Spacing="14"><TextBlock Text="▤" FontSize="18" Width="24" TextAlignment="Center" /><TextBlock Text="Report" VerticalAlignment="Center" /></StackPanel></Button>
+          </Grid>
         </StackPanel>
 
         <StackPanel Grid.Row="2" Spacing="1">
@@ -82,27 +77,23 @@
                 <ProgressBar IsIndeterminate="True" IsVisible="{Binding IsBusy}" Height="3" Margin="0,18,80,0" />
                 <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,40,0,0"><TextBlock Text="▱" Foreground="{StaticResource AgenTealBrush}" FontSize="21" /><TextBlock Text="Machine analysis stays on this device." Foreground="{StaticResource AgenMutedBrush}" FontSize="14" VerticalAlignment="Center" /></StackPanel>
               </StackPanel>
-              <Grid Grid.Column="1" RowDefinitions="*,Auto,*" VerticalAlignment="Center" MinHeight="500">
-                <StackPanel Grid.Row="1" HorizontalAlignment="Center" Width="390" Spacing="12">
-                  <Border Width="74" Height="74" CornerRadius="37" BorderThickness="2" BorderBrush="{StaticResource AgenTealBrush}" HorizontalAlignment="Center"><TextBlock Text="✓" FontSize="35" Foreground="{StaticResource AgenTealBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border>
-                  <TextBlock Text="{Binding StatusTitle}" FontSize="26" FontWeight="SemiBold" TextAlignment="Center" Margin="0,9,0,0" />
-                  <TextBlock Text="{Binding StatusMessage}" Classes="subtitle" TextAlignment="Center" TextWrapping="Wrap" />
-                  <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,16,0,12" />
-                  <TextBlock Text="You stay in control of what gets installed." Foreground="{StaticResource AgenMutedBrush}" FontSize="14" TextAlignment="Center" />
-                </StackPanel>
-              </Grid>
+              <StackPanel Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" Width="390" Spacing="12">
+                <Border Width="74" Height="74" CornerRadius="37" BorderThickness="2" BorderBrush="{StaticResource AgenTealBrush}" HorizontalAlignment="Center"><TextBlock Text="✓" FontSize="35" Foreground="{StaticResource AgenTealBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border>
+                <TextBlock Text="{Binding StatusTitle}" FontSize="26" FontWeight="SemiBold" TextAlignment="Center" Margin="0,9,0,0" />
+                <TextBlock Text="{Binding StatusMessage}" Classes="subtitle" TextAlignment="Center" TextWrapping="Wrap" />
+                <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,16,0,12" />
+                <TextBlock Text="You stay in control of what gets installed." Foreground="{StaticResource AgenMutedBrush}" FontSize="14" TextAlignment="Center" />
+              </StackPanel>
             </Grid>
           </Grid>
 
           <Grid x:Name="YourPcPanel" IsVisible="False" MaxWidth="1120" HorizontalAlignment="Left">
-            <Grid RowDefinitions="Auto,Auto,*">
-              <StackPanel Grid.Row="0">
-                <TextBlock Classes="eyebrow" Text="YOUR PC" Margin="0,0,0,22" />
-                <TextBlock Classes="pageTitle" Text="Your PC" />
-                <TextBlock Classes="subtitle" Text="AgenStart detected the essentials locally." Margin="0,13,0,0" />
-                <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,30,0,26" />
-              </StackPanel>
-              <Grid Grid.Row="1" ColumnDefinitions="1.35*,0.65*" ColumnSpacing="52">
+            <StackPanel>
+              <TextBlock Classes="eyebrow" Text="YOUR PC" Margin="0,0,0,22" />
+              <TextBlock Classes="pageTitle" Text="Your PC" />
+              <TextBlock Classes="subtitle" Text="AgenStart detected the essentials locally." Margin="0,13,0,0" />
+              <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,30,0,26" />
+              <Grid ColumnDefinitions="1.35*,0.65*" ColumnSpacing="52">
                 <StackPanel Grid.Column="0">
                   <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="▣" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding OperatingSystem}" FontSize="17" /><TextBlock Grid.Column="2" Text="Detected" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
                   <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="◉" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding Cpu}" FontSize="17" /><TextBlock Grid.Column="2" Text="Detected" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
@@ -113,10 +104,7 @@
                   <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="64" FontSize="13" FontWeight="Bold" /><TextBlock Grid.Column="1" Text="{Binding Architecture}" FontSize="17" /><TextBlock Grid.Column="2" Text="Supported" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
                   <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="⬡" FontSize="20" /><TextBlock Grid.Column="1" Text="{Binding WinGet}" FontSize="17" /><TextBlock Grid.Column="2" Text="Available" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
                   <Border Classes="dataRow"><Grid ColumnDefinitions="42,*,150"><TextBlock Text="i" FontSize="18" FontWeight="SemiBold" /><TextBlock Grid.Column="1" Text="{Binding WinGetVersion, StringFormat='WinGet version {0}'}" FontSize="17" /><TextBlock Grid.Column="2" Text="Detected" Foreground="{StaticResource AgenMutedBrush}" /></Grid></Border>
-                  <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,26,0,0">
-                    <Button Classes="primary" Content="Choose usage profile" Click="ContinueToProfile_OnClick" />
-                    <Button x:Name="RefreshButton" Classes="secondary" Content="Refresh analysis" Click="RefreshButton_OnClick" />
-                  </StackPanel>
+                  <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,26,0,0"><Button Classes="primary" Content="Choose usage profile" Click="ContinueToProfile_OnClick" /><Button x:Name="RefreshButton" Classes="secondary" Content="Refresh analysis" Click="RefreshButton_OnClick" /></StackPanel>
                 </StackPanel>
                 <StackPanel Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" Width="310" Spacing="12">
                   <Border Width="74" Height="74" CornerRadius="37" BorderThickness="2" BorderBrush="{StaticResource AgenTealBrush}" HorizontalAlignment="Center"><TextBlock Text="✓" FontSize="35" Foreground="{StaticResource AgenTealBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border>
@@ -124,8 +112,8 @@
                   <TextBlock Text="{Binding StatusMessage}" Classes="subtitle" TextWrapping="Wrap" TextAlignment="Center" />
                 </StackPanel>
               </Grid>
-              <Border Grid.Row="2" BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,1,0,0" Margin="0,30,0,0" Padding="0,24,0,0"><StackPanel Orientation="Horizontal" Spacing="12"><TextBlock Text="▱" Foreground="{StaticResource AgenTealBrush}" FontSize="21" /><TextBlock Text="{Binding AnalysisDiagnostic}" Foreground="{StaticResource AgenMutedBrush}" FontSize="14" VerticalAlignment="Center" /></StackPanel></Border>
-            </Grid>
+              <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,1,0,0" Margin="0,30,0,0" Padding="0,24,0,0"><StackPanel Orientation="Horizontal" Spacing="12"><TextBlock Text="▱" Foreground="{StaticResource AgenTealBrush}" FontSize="21" /><TextBlock Text="{Binding AnalysisDiagnostic}" Foreground="{StaticResource AgenMutedBrush}" FontSize="14" VerticalAlignment="Center" /></StackPanel></Border>
+            </StackPanel>
           </Grid>
 
           <Grid x:Name="UsageProfilePanel" IsVisible="False" MaxWidth="1120" HorizontalAlignment="Left">
@@ -142,18 +130,12 @@
                   <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="1" CornerRadius="7" Padding="16,10"><RadioButton GroupName="UsageProfile" Click="BusinessProfile_OnChecked"><StackPanel><TextBlock Text="Business" FontSize="17" FontWeight="SemiBold" /><TextBlock Text="Office, communication, productivity and collaboration." Foreground="{StaticResource AgenMutedBrush}" /></StackPanel></RadioButton></Border>
                   <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="1" CornerRadius="7" Padding="16,10"><RadioButton GroupName="UsageProfile" Click="CreationProfile_OnChecked"><StackPanel><TextBlock Text="Creation" FontSize="17" FontWeight="SemiBold" /><TextBlock Text="Design, media, content and creative workflows." Foreground="{StaticResource AgenMutedBrush}" /></StackPanel></RadioButton></Border>
                   <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="1" CornerRadius="7" Padding="16,10"><RadioButton GroupName="UsageProfile" Click="TrainingProfile_OnChecked"><StackPanel><TextBlock Text="Training" FontSize="17" FontWeight="SemiBold" /><TextBlock Text="Learning, course tools and guided study setups." Foreground="{StaticResource AgenMutedBrush}" /></StackPanel></RadioButton></Border>
-                  <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,25,0,0">
-                    <Button Classes="primary" Content="Build my recommendations" Click="BuildRecommendationsButton_OnClick" />
-                    <Button Classes="secondary" Content="Back" Click="ProfileBackButton_OnClick" />
-                  </StackPanel>
+                  <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,25,0,0"><Button Classes="primary" Content="Build my recommendations" Click="BuildRecommendationsButton_OnClick" /><Button Classes="secondary" Content="Back" Click="ProfileBackButton_OnClick" /></StackPanel>
                   <ProgressBar IsIndeterminate="True" IsVisible="{Binding IsBusy}" Height="3" Margin="0,15,80,0" />
                 </StackPanel>
                 <StackPanel Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" Width="300" Spacing="12">
                   <Border Width="68" Height="68" CornerRadius="34" BorderThickness="2" BorderBrush="{StaticResource AgenTealBrush}" HorizontalAlignment="Center"><TextBlock Text="&lt;/&gt;" Foreground="{StaticResource AgenTealBrush}" FontSize="19" FontWeight="SemiBold" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border>
-                  <TextBlock Text="Selected:" Foreground="{StaticResource AgenMutedBrush}" TextAlignment="Center" Margin="0,8,0,0" />
-                  <TextBlock Text="{Binding SelectedProfileName}" FontSize="24" FontWeight="SemiBold" TextAlignment="Center" />
-                  <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,8" />
-                  <TextBlock Text="{Binding SelectedProfileDescription}" Classes="subtitle" TextWrapping="Wrap" TextAlignment="Center" />
+                  <TextBlock Text="Selected:" Foreground="{StaticResource AgenMutedBrush}" TextAlignment="Center" Margin="0,8,0,0" /><TextBlock Text="{Binding SelectedProfileName}" FontSize="24" FontWeight="SemiBold" TextAlignment="Center" /><Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,8" /><TextBlock Text="{Binding SelectedProfileDescription}" Classes="subtitle" TextWrapping="Wrap" TextAlignment="Center" />
                 </StackPanel>
               </Grid>
             </StackPanel>
@@ -162,43 +144,66 @@
           <Grid x:Name="RecommendationsPanel" IsVisible="False" MaxWidth="1160" HorizontalAlignment="Left">
             <StackPanel>
               <Grid ColumnDefinitions="*,Auto" ColumnSpacing="34">
-                <StackPanel>
-                  <TextBlock Classes="eyebrow" Text="RECOMMENDATIONS" Margin="0,0,0,20" />
-                  <TextBlock Classes="pageTitle" Text="Recommended for this PC" />
-                  <TextBlock Classes="subtitle" Text="{Binding RecommendationStatus}" Margin="0,12,0,0" TextWrapping="Wrap" />
-                </StackPanel>
-                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="28" VerticalAlignment="Bottom" Margin="0,0,0,5">
-                  <StackPanel><TextBlock Text="{Binding RecommendationCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="recommendations" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel>
-                  <StackPanel><TextBlock Text="{Binding SelectedCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="selected" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel>
-                  <StackPanel><TextBlock Text="{Binding AlreadyInstalledCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="already installed" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel>
-                  <StackPanel><TextBlock Text="{Binding OptionalCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="optional" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel>
-                </StackPanel>
+                <StackPanel><TextBlock Classes="eyebrow" Text="RECOMMENDATIONS" Margin="0,0,0,20" /><TextBlock Classes="pageTitle" Text="Recommended for this PC" /><TextBlock Classes="subtitle" Text="{Binding RecommendationStatus}" Margin="0,12,0,0" TextWrapping="Wrap" /></StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="28" VerticalAlignment="Bottom" Margin="0,0,0,5"><StackPanel><TextBlock Text="{Binding RecommendationCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="recommendations" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel><StackPanel><TextBlock Text="{Binding SelectedCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="selected" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel><StackPanel><TextBlock Text="{Binding AlreadyInstalledCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="already installed" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel></StackPanel>
               </Grid>
               <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,28,0,8" />
-
               <ItemsControl ItemsSource="{Binding Recommendations}">
-                <ItemsControl.ItemTemplate>
-                  <DataTemplate x:DataType="vm:RecommendationRowViewModel">
-                    <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,0,0,1" Padding="10,13">
-                      <Grid ColumnDefinitions="58,*,190,54" ColumnSpacing="16">
-                        <Border Width="38" Height="38" CornerRadius="8" Background="#E7EFEC" VerticalAlignment="Center"><TextBlock Text="{Binding Initials}" Foreground="{StaticResource AgenTealBrush}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border>
-                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                          <TextBlock Text="{Binding Name}" FontSize="16" FontWeight="SemiBold" />
-                          <TextBlock Text="{Binding Reason}" Foreground="{StaticResource AgenMutedBrush}" FontSize="13" TextTrimming="CharacterEllipsis" />
-                        </StackPanel>
-                        <TextBlock Grid.Column="2" Text="{Binding Status}" Foreground="{StaticResource AgenTextBrush}" VerticalAlignment="Center" />
-                        <CheckBox Grid.Column="3" IsChecked="{Binding IsSelected, Mode=TwoWay}" IsEnabled="{Binding CanSelect}" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                      </Grid>
-                    </Border>
-                  </DataTemplate>
-                </ItemsControl.ItemTemplate>
+                <ItemsControl.ItemTemplate><DataTemplate x:DataType="vm:RecommendationRowViewModel"><Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,0,0,1" Padding="10,13"><Grid ColumnDefinitions="58,*,190,54" ColumnSpacing="16"><Border Width="38" Height="38" CornerRadius="8" Background="#E7EFEC" VerticalAlignment="Center"><TextBlock Text="{Binding Initials}" Foreground="{StaticResource AgenTealBrush}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border><StackPanel Grid.Column="1" VerticalAlignment="Center"><TextBlock Text="{Binding Name}" FontSize="16" FontWeight="SemiBold" /><TextBlock Text="{Binding Reason}" Foreground="{StaticResource AgenMutedBrush}" FontSize="13" TextTrimming="CharacterEllipsis" /></StackPanel><TextBlock Grid.Column="2" Text="{Binding Status}" VerticalAlignment="Center" /><CheckBox Grid.Column="3" IsChecked="{Binding IsSelected, Mode=TwoWay}" IsEnabled="{Binding CanSelect}" HorizontalAlignment="Center" VerticalAlignment="Center" /></Grid></Border></DataTemplate></ItemsControl.ItemTemplate>
               </ItemsControl>
+              <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,22,0,0"><Button Classes="primary" Content="Review setup" IsEnabled="{Binding CanReview}" Click="ReviewSetupButton_OnClick" /><Button Classes="secondary" Content="Select essentials only" Click="SelectEssentialsButton_OnClick" /></StackPanel>
+              <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,1,0,0" Margin="0,24,0,0" Padding="0,20,0,0"><TextBlock Text="Nothing will be installed until you approve the final setup." Foreground="{StaticResource AgenMutedBrush}" FontSize="14" /></Border>
+            </StackPanel>
+          </Grid>
 
-              <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,22,0,0">
-                <Button Classes="primary" Content="Review setup" IsEnabled="False" />
-                <Button Classes="secondary" Content="Select essentials only" Click="SelectEssentialsButton_OnClick" />
-              </StackPanel>
-              <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,1,0,0" Margin="0,24,0,0" Padding="0,20,0,0"><StackPanel Orientation="Horizontal" Spacing="12"><TextBlock Text="▱" Foreground="{StaticResource AgenTealBrush}" FontSize="21" /><TextBlock Text="Nothing will be installed until you approve the final setup." Foreground="{StaticResource AgenMutedBrush}" FontSize="14" VerticalAlignment="Center" /></StackPanel></Border>
+          <Grid x:Name="ReviewPanel" IsVisible="False" MaxWidth="1160" HorizontalAlignment="Left">
+            <StackPanel>
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="32">
+                <StackPanel><TextBlock Classes="eyebrow" Text="REVIEW" Margin="0,0,0,20" /><TextBlock Classes="pageTitle" Text="Review your setup" /><TextBlock Classes="subtitle" Text="Nothing will be installed until you approve this plan." Margin="0,12,0,0" /></StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="30" VerticalAlignment="Bottom" Margin="0,0,0,5"><StackPanel><TextBlock Text="{Binding ReviewTotalCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="in plan" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel><StackPanel><TextBlock Text="{Binding ReviewAlreadyInstalledCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="already installed" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel><StackPanel><TextBlock Text="{Binding ReviewInstallCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" TextAlignment="Center" /><TextBlock Text="to install" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel></StackPanel>
+              </Grid>
+              <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,28,0,8" />
+              <ItemsControl ItemsSource="{Binding ReviewItems}"><ItemsControl.ItemTemplate><DataTemplate x:DataType="vm:ReviewRowViewModel"><Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,0,0,1" Padding="10,14"><Grid ColumnDefinitions="58,*,180,110" ColumnSpacing="16"><Border Width="38" Height="38" CornerRadius="8" Background="#E7EFEC"><TextBlock Text="{Binding Initials}" Foreground="{StaticResource AgenTealBrush}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border><StackPanel Grid.Column="1"><TextBlock Text="{Binding Name}" FontSize="16" FontWeight="SemiBold" /><TextBlock Text="{Binding Reason}" Foreground="{StaticResource AgenMutedBrush}" FontSize="13" TextTrimming="CharacterEllipsis" /></StackPanel><TextBlock Grid.Column="2" Text="{Binding Status}" VerticalAlignment="Center" /><Button Grid.Column="3" Content="Remove" Background="Transparent" BorderThickness="0" Foreground="{StaticResource AgenTealBrush}" IsVisible="{Binding CanRemove}" Click="RemoveReviewItem_OnClick" /></Grid></Border></DataTemplate></ItemsControl.ItemTemplate></ItemsControl>
+              <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="1" CornerRadius="8" Padding="18" Margin="0,24,0,0"><CheckBox IsChecked="{Binding AgreementsAccepted, Mode=TwoWay}"><StackPanel Margin="8,0,0,0"><TextBlock Text="Allow WinGet to accept required package and source agreements for this approved setup." FontWeight="SemiBold" /><TextBlock Text="Only the applications listed above are eligible for installation." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" /></StackPanel></CheckBox></Border>
+              <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,20,0,0"><Button Classes="primary" Content="Start installation" IsEnabled="{Binding CanStartInstallation}" Click="StartInstallationButton_OnClick" /><Button Classes="secondary" Content="Back to recommendations" Click="ReviewBackButton_OnClick" /></StackPanel>
+              <TextBlock Text="AgenStart will install only the applications shown above." Foreground="{StaticResource AgenMutedBrush}" FontSize="14" Margin="0,22,0,0" />
+            </StackPanel>
+          </Grid>
+
+          <Grid x:Name="InstallationPanel" IsVisible="False" MaxWidth="1160" HorizontalAlignment="Left">
+            <StackPanel>
+              <TextBlock Classes="eyebrow" Text="INSTALLATION" Margin="0,0,0,20" />
+              <TextBlock Classes="pageTitle" Text="Setting up your PC" />
+              <TextBlock Classes="subtitle" Text="{Binding InstallationStatus}" Margin="0,12,0,0" TextWrapping="Wrap" />
+              <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,30,0,28" />
+              <Grid ColumnDefinitions="1.15*,0.85*" ColumnSpacing="52">
+                <StackPanel Grid.Column="0">
+                  <TextBlock Text="Installation queue" FontSize="20" FontWeight="SemiBold" Margin="0,0,0,10" />
+                  <ItemsControl ItemsSource="{Binding InstallationItems}"><ItemsControl.ItemTemplate><DataTemplate x:DataType="vm:InstallationRowViewModel"><Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,0,0,1" Padding="10,13"><Grid ColumnDefinitions="54,*,170,90" ColumnSpacing="14"><Border Width="36" Height="36" CornerRadius="8" Background="#E7EFEC"><TextBlock Text="{Binding Initials}" Foreground="{StaticResource AgenTealBrush}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border><StackPanel Grid.Column="1"><TextBlock Text="{Binding Name}" FontSize="16" FontWeight="SemiBold" /><TextBlock Text="{Binding Message}" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" TextTrimming="CharacterEllipsis" /></StackPanel><TextBlock Grid.Column="2" Text="{Binding Status}" VerticalAlignment="Center" /><Button Grid.Column="3" Content="Retry" Background="Transparent" BorderThickness="0" Foreground="{StaticResource AgenTealBrush}" IsVisible="{Binding CanRetry}" Click="RetryInstallationItem_OnClick" /></Grid></Border></DataTemplate></ItemsControl.ItemTemplate></ItemsControl>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="16">
+                  <TextBlock Text="Current task" FontSize="18" FontWeight="SemiBold" /><TextBlock Text="{Binding CurrentInstallationName}" FontSize="26" FontWeight="SemiBold" /><ProgressBar IsIndeterminate="True" IsVisible="{Binding IsInstalling}" Height="5" />
+                  <Grid ColumnDefinitions="*,*,*" Margin="0,12,0,0"><StackPanel><TextBlock Text="{Binding InstallationCompletedCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="22" FontWeight="SemiBold" /><TextBlock Text="completed" Foreground="{StaticResource AgenMutedBrush}" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="{Binding InstallationRemainingCount}" FontSize="22" FontWeight="SemiBold" /><TextBlock Text="remaining" Foreground="{StaticResource AgenMutedBrush}" /></StackPanel><StackPanel Grid.Column="2"><TextBlock Text="{Binding InstallationFailedCount}" FontSize="22" FontWeight="SemiBold" /><TextBlock Text="failed" Foreground="{StaticResource AgenMutedBrush}" /></StackPanel></Grid>
+                  <Button Classes="secondary" Content="Cancel installation" IsEnabled="{Binding IsInstalling}" Click="CancelInstallationButton_OnClick" Margin="0,10,0,0" />
+                  <Button Classes="secondary" Content="View report" IsVisible="{Binding HasReport}" Click="ViewReportButton_OnClick" />
+                  <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,10,0,0" /><TextBlock Text="Packages are resolved through exact trusted provider identities. AgenStart does not execute arbitrary shell commands." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" TextWrapping="Wrap" />
+                </StackPanel>
+              </Grid>
+            </StackPanel>
+          </Grid>
+
+          <Grid x:Name="ReportPanel" IsVisible="False" MaxWidth="1160" HorizontalAlignment="Left">
+            <StackPanel>
+              <TextBlock Classes="eyebrow" Text="REPORT" Margin="0,0,0,20" />
+              <TextBlock Classes="pageTitle" Text="Your PC is ready" />
+              <TextBlock Classes="subtitle" Text="{Binding ReportStatus}" Margin="0,12,0,0" TextWrapping="Wrap" />
+              <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,28,0,24" />
+              <Grid ColumnDefinitions="90,*,*,*,*" ColumnSpacing="18"><Border Width="64" Height="64" CornerRadius="32" BorderBrush="{StaticResource AgenTealBrush}" BorderThickness="2"><TextBlock Text="✓" Foreground="{StaticResource AgenTealBrush}" FontSize="30" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border><StackPanel Grid.Column="1"><TextBlock Text="{Binding ReportProcessedCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="22" FontWeight="SemiBold" /><TextBlock Text="applications processed" Foreground="{StaticResource AgenMutedBrush}" /></StackPanel><StackPanel Grid.Column="2"><TextBlock Text="{Binding ReportInstalledCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="22" FontWeight="SemiBold" /><TextBlock Text="installed" Foreground="{StaticResource AgenMutedBrush}" /></StackPanel><StackPanel Grid.Column="3"><TextBlock Text="{Binding ReportAlreadyInstalledCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="22" FontWeight="SemiBold" /><TextBlock Text="already installed" Foreground="{StaticResource AgenMutedBrush}" /></StackPanel><StackPanel Grid.Column="4"><TextBlock Text="{Binding ReportFailedCount}" FontSize="22" FontWeight="SemiBold" /><TextBlock Text="failed" Foreground="{StaticResource AgenMutedBrush}" /></StackPanel></Grid>
+              <TextBlock Text="Installation results" FontSize="20" FontWeight="SemiBold" Margin="0,32,0,10" />
+              <ItemsControl ItemsSource="{Binding ReportItems}"><ItemsControl.ItemTemplate><DataTemplate x:DataType="vm:ReportRowViewModel"><Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,0,0,1" Padding="10,13"><Grid ColumnDefinitions="54,*,190,160" ColumnSpacing="14"><Border Width="36" Height="36" CornerRadius="8" Background="#E7EFEC"><TextBlock Text="{Binding Initials}" Foreground="{StaticResource AgenTealBrush}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" /></Border><TextBlock Grid.Column="1" Text="{Binding Name}" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" /><TextBlock Grid.Column="2" Text="{Binding Result}" VerticalAlignment="Center" /><TextBlock Grid.Column="3" Text="{Binding InstalledVersion}" Foreground="{StaticResource AgenMutedBrush}" VerticalAlignment="Center" /></Grid></Border></DataTemplate></ItemsControl.ItemTemplate></ItemsControl>
+              <Border IsVisible="{Binding ReportRequiresReboot}" BorderBrush="#AAB2B2" BorderThickness="1" CornerRadius="8" Padding="16" Margin="0,20,0,0"><StackPanel><TextBlock Text="Restart recommended" FontWeight="SemiBold" /><TextBlock Text="One or more installed applications require Windows to restart before all features become available." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" /></StackPanel></Border>
+              <Grid ColumnDefinitions="*,Auto" Margin="0,22,0,0"><StackPanel Orientation="Horizontal" Spacing="14"><Button Classes="primary" Content="Finish" Click="FinishButton_OnClick" /><Button Classes="secondary" Content="Export this setup" IsEnabled="False" /></StackPanel><StackPanel Grid.Column="1"><TextBlock Text="Completed at" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /><TextBlock Text="{Binding ReportCompletedAt}" FontWeight="SemiBold" /></StackPanel></Grid>
+              <TextBlock Text="Setup export will be enabled by the reproducible profiles milestone." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,20,0,0" />
             </StackPanel>
           </Grid>
         </Grid>

--- a/src/AgenStart.Desktop/Views/MainWindow.axaml.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using AgenStart.Core.Catalogue;
@@ -20,16 +21,21 @@ public sealed partial class MainWindow : Window
         YourPcButton.IsEnabled = false;
         UsageProfileButton.IsEnabled = false;
         RecommendationsButton.IsEnabled = false;
+        ReviewButton.IsEnabled = false;
+        InstallationButton.IsEnabled = false;
+        ReportButton.IsEnabled = false;
+
+        _viewModel.PropertyChanged += ViewModel_OnPropertyChanged;
         Closed += OnClosed;
     }
 
     private void OverviewButton_OnClick(object? sender, RoutedEventArgs e) => ShowOverview();
-
     private void YourPcButton_OnClick(object? sender, RoutedEventArgs e) => ShowYourPc();
-
     private void UsageProfileButton_OnClick(object? sender, RoutedEventArgs e) => ShowUsageProfile();
-
     private void RecommendationsButton_OnClick(object? sender, RoutedEventArgs e) => ShowRecommendations();
+    private void ReviewButton_OnClick(object? sender, RoutedEventArgs e) => ShowReview();
+    private void InstallationButton_OnClick(object? sender, RoutedEventArgs e) => ShowInstallation();
+    private void ReportButton_OnClick(object? sender, RoutedEventArgs e) => ShowReport();
 
     private async void AnalyzeButton_OnClick(object? sender, RoutedEventArgs e)
     {
@@ -54,23 +60,19 @@ public sealed partial class MainWindow : Window
     }
 
     private void ContinueToProfile_OnClick(object? sender, RoutedEventArgs e) => ShowUsageProfile();
-
     private void ProfileBackButton_OnClick(object? sender, RoutedEventArgs e) => ShowYourPc();
 
-    private void PersonalProfile_OnChecked(object? sender, RoutedEventArgs e) =>
-        _viewModel.SelectProfile(UserProfile.Personal);
+    private void PersonalProfile_OnChecked(object? sender, RoutedEventArgs e) => SelectProfile(UserProfile.Personal);
+    private void DevelopmentProfile_OnChecked(object? sender, RoutedEventArgs e) => SelectProfile(UserProfile.Development);
+    private void BusinessProfile_OnChecked(object? sender, RoutedEventArgs e) => SelectProfile(UserProfile.Business);
+    private void CreationProfile_OnChecked(object? sender, RoutedEventArgs e) => SelectProfile(UserProfile.Creation);
+    private void TrainingProfile_OnChecked(object? sender, RoutedEventArgs e) => SelectProfile(UserProfile.Training);
 
-    private void DevelopmentProfile_OnChecked(object? sender, RoutedEventArgs e) =>
-        _viewModel.SelectProfile(UserProfile.Development);
-
-    private void BusinessProfile_OnChecked(object? sender, RoutedEventArgs e) =>
-        _viewModel.SelectProfile(UserProfile.Business);
-
-    private void CreationProfile_OnChecked(object? sender, RoutedEventArgs e) =>
-        _viewModel.SelectProfile(UserProfile.Creation);
-
-    private void TrainingProfile_OnChecked(object? sender, RoutedEventArgs e) =>
-        _viewModel.SelectProfile(UserProfile.Training);
+    private void SelectProfile(UserProfile profile)
+    {
+        _viewModel.SelectProfile(profile);
+        RecommendationsButton.IsEnabled = false;
+    }
 
     private async void BuildRecommendationsButton_OnClick(object? sender, RoutedEventArgs e)
     {
@@ -85,39 +87,123 @@ public sealed partial class MainWindow : Window
     private void SelectEssentialsButton_OnClick(object? sender, RoutedEventArgs e) =>
         _viewModel.SelectEssentialsOnly();
 
-    private void ShowOverview() => ShowPage(
-        OverviewPanel,
-        OverviewButton,
-        OverviewStripe);
-
-    private void ShowYourPc()
+    private void ReviewSetupButton_OnClick(object? sender, RoutedEventArgs e)
     {
-        if (!YourPcButton.IsEnabled)
+        if (_viewModel.PrepareReview())
+        {
+            ShowReview();
+        }
+    }
+
+    private void ReviewBackButton_OnClick(object? sender, RoutedEventArgs e) => ShowRecommendations();
+
+    private void RemoveReviewItem_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { DataContext: ReviewRowViewModel row })
         {
             return;
         }
 
-        ShowPage(YourPcPanel, YourPcButton, YourPcStripe);
+        _viewModel.RemoveFromReview(row.ApplicationId);
+        if (!_viewModel.HasReview)
+        {
+            ShowRecommendations();
+        }
+    }
+
+    private async void StartInstallationButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (!_viewModel.CanStartInstallation)
+        {
+            return;
+        }
+
+        InstallationButton.IsEnabled = true;
+        ShowInstallation();
+        await _viewModel.StartInstallationAsync(_lifetimeCancellation.Token);
+
+        if (_viewModel.HasReport)
+        {
+            ReportButton.IsEnabled = true;
+            if (_viewModel.InstallationFailedCount == 0)
+            {
+                ShowReport();
+            }
+        }
+    }
+
+    private void CancelInstallationButton_OnClick(object? sender, RoutedEventArgs e) =>
+        _viewModel.CancelInstallation();
+
+    private async void RetryInstallationItem_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { DataContext: InstallationRowViewModel row })
+        {
+            return;
+        }
+
+        await _viewModel.RetryInstallationAsync(row.ApplicationId, _lifetimeCancellation.Token);
+        if (_viewModel.HasReport)
+        {
+            ReportButton.IsEnabled = true;
+            if (_viewModel.InstallationFailedCount == 0)
+            {
+                ShowReport();
+            }
+        }
+    }
+
+    private void ViewReportButton_OnClick(object? sender, RoutedEventArgs e) => ShowReport();
+    private void FinishButton_OnClick(object? sender, RoutedEventArgs e) => ShowOverview();
+
+    private void ShowOverview() => ShowPage(OverviewPanel, OverviewButton, OverviewStripe);
+
+    private void ShowYourPc()
+    {
+        if (YourPcButton.IsEnabled)
+        {
+            ShowPage(YourPcPanel, YourPcButton, YourPcStripe);
+        }
     }
 
     private void ShowUsageProfile()
     {
-        if (!UsageProfileButton.IsEnabled)
+        if (UsageProfileButton.IsEnabled)
         {
-            return;
+            ShowPage(UsageProfilePanel, UsageProfileButton, UsageProfileStripe);
         }
-
-        ShowPage(UsageProfilePanel, UsageProfileButton, UsageProfileStripe);
     }
 
     private void ShowRecommendations()
     {
-        if (!RecommendationsButton.IsEnabled)
+        if (RecommendationsButton.IsEnabled)
         {
-            return;
+            ShowPage(RecommendationsPanel, RecommendationsButton, RecommendationsStripe);
         }
+    }
 
-        ShowPage(RecommendationsPanel, RecommendationsButton, RecommendationsStripe);
+    private void ShowReview()
+    {
+        if (_viewModel.HasReview)
+        {
+            ShowPage(ReviewPanel, ReviewButton, ReviewStripe);
+        }
+    }
+
+    private void ShowInstallation()
+    {
+        if (InstallationButton.IsEnabled)
+        {
+            ShowPage(InstallationPanel, InstallationButton, InstallationStripe);
+        }
+    }
+
+    private void ShowReport()
+    {
+        if (_viewModel.HasReport)
+        {
+            ShowPage(ReportPanel, ReportButton, ReportStripe);
+        }
     }
 
     private void ShowPage(Control panel, Button activeButton, Border activeStripe)
@@ -126,16 +212,43 @@ public sealed partial class MainWindow : Window
         YourPcPanel.IsVisible = ReferenceEquals(panel, YourPcPanel);
         UsageProfilePanel.IsVisible = ReferenceEquals(panel, UsageProfilePanel);
         RecommendationsPanel.IsVisible = ReferenceEquals(panel, RecommendationsPanel);
+        ReviewPanel.IsVisible = ReferenceEquals(panel, ReviewPanel);
+        InstallationPanel.IsVisible = ReferenceEquals(panel, InstallationPanel);
+        ReportPanel.IsVisible = ReferenceEquals(panel, ReportPanel);
 
         OverviewStripe.IsVisible = ReferenceEquals(activeStripe, OverviewStripe);
         YourPcStripe.IsVisible = ReferenceEquals(activeStripe, YourPcStripe);
         UsageProfileStripe.IsVisible = ReferenceEquals(activeStripe, UsageProfileStripe);
         RecommendationsStripe.IsVisible = ReferenceEquals(activeStripe, RecommendationsStripe);
+        ReviewStripe.IsVisible = ReferenceEquals(activeStripe, ReviewStripe);
+        InstallationStripe.IsVisible = ReferenceEquals(activeStripe, InstallationStripe);
+        ReportStripe.IsVisible = ReferenceEquals(activeStripe, ReportStripe);
 
         SetActive(OverviewButton, ReferenceEquals(activeButton, OverviewButton));
         SetActive(YourPcButton, ReferenceEquals(activeButton, YourPcButton));
         SetActive(UsageProfileButton, ReferenceEquals(activeButton, UsageProfileButton));
         SetActive(RecommendationsButton, ReferenceEquals(activeButton, RecommendationsButton));
+        SetActive(ReviewButton, ReferenceEquals(activeButton, ReviewButton));
+        SetActive(InstallationButton, ReferenceEquals(activeButton, InstallationButton));
+        SetActive(ReportButton, ReferenceEquals(activeButton, ReportButton));
+    }
+
+    private void ViewModel_OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(MainWindowViewModel.HasReview))
+        {
+            ReviewButton.IsEnabled = _viewModel.HasReview;
+        }
+
+        if (e.PropertyName is nameof(MainWindowViewModel.InstallationTotalCount) or nameof(MainWindowViewModel.IsInstalling))
+        {
+            InstallationButton.IsEnabled = _viewModel.InstallationTotalCount > 0 || _viewModel.IsInstalling || _viewModel.HasReport;
+        }
+
+        if (e.PropertyName == nameof(MainWindowViewModel.HasReport))
+        {
+            ReportButton.IsEnabled = _viewModel.HasReport;
+        }
     }
 
     private static void SetActive(Button button, bool isActive)
@@ -156,7 +269,9 @@ public sealed partial class MainWindow : Window
 
     private void OnClosed(object? sender, EventArgs e)
     {
+        _viewModel.PropertyChanged -= ViewModel_OnPropertyChanged;
         _lifetimeCancellation.Cancel();
+        _viewModel.Dispose();
         _lifetimeCancellation.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

Completes the next guided desktop slice for #8 by wiring the approved recommendations into the existing installation application layer.

### Review
- builds a review plan from the real recommendation selection
- keeps already-installed applications visible without scheduling them again
- supports removing selected applications before execution
- requires explicit consent before passing WinGet package/source agreement flags
- keeps exact catalogue package identities as the installation source of truth

### Installation
- reuses `InstallationOrchestrator`, `InstallationSession`, `WinGetProvider` and `SoftwareInventoryInstallationVerifier`
- executes only explicitly approved selections
- surfaces real queue states instead of synthetic percentage progress
- supports safe cancellation and orchestrator-approved retry
- keeps failures attached to the affected application
- preserves exact provider/source resolution and post-install verification

### Report
- renders final installed / already-installed / failed outcomes
- includes verified installed versions when available
- surfaces restart requirements
- keeps setup export disabled until #9 is implemented

### Security boundaries
- no arbitrary shell execution
- no fuzzy package lookup
- no installation before explicit review approval
- package/source agreement acceptance is explicit and scoped to the approved setup
- success is not reported without normalized installed-software verification

Part of #8.