### PR TITLE
feat: add local history and settings screens

### DIFF
--- a/src/AgenStart.Desktop/LocalData/LocalExperienceStore.cs
+++ b/src/AgenStart.Desktop/LocalData/LocalExperienceStore.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AgenStart.Desktop.LocalData;
+
+public sealed record DesktopSettings(bool AnalyzeOnStartup = true);
+
+public sealed record SetupHistoryApplication(
+    string ApplicationId,
+    string Name,
+    string Result,
+    string? InstalledVersion);
+
+public sealed record SetupHistoryEntry(
+    Guid Id,
+    DateTimeOffset CompletedAtUtc,
+    string Profile,
+    int ProcessedCount,
+    int InstalledCount,
+    int AlreadyInstalledCount,
+    int FailedCount,
+    int SkippedCount,
+    int CancelledCount,
+    bool RequiresReboot,
+    IReadOnlyList<SetupHistoryApplication> Applications);
+
+public sealed class LocalExperienceStore
+{
+    private const int MaxHistoryEntries = 50;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly string _directoryPath;
+    private readonly string _settingsPath;
+    private readonly string _historyPath;
+
+    public LocalExperienceStore(string? baseDirectory = null)
+    {
+        _directoryPath = baseDirectory ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "AgenStart");
+        _settingsPath = Path.Combine(_directoryPath, "settings.json");
+        _historyPath = Path.Combine(_directoryPath, "history.json");
+    }
+
+    public async Task<DesktopSettings> LoadSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(_settingsPath))
+            {
+                return new DesktopSettings();
+            }
+
+            await using var stream = File.OpenRead(_settingsPath);
+            return await JsonSerializer.DeserializeAsync<DesktopSettings>(stream, _jsonOptions, cancellationToken)
+                .ConfigureAwait(false) ?? new DesktopSettings();
+        }
+        catch (JsonException)
+        {
+            return new DesktopSettings();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task SaveSettingsAsync(DesktopSettings settings, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(_directoryPath);
+            await WriteAtomicAsync(_settingsPath, settings, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<SetupHistoryEntry>> LoadHistoryAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await LoadHistoryUnsafeAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task UpsertHistoryAsync(SetupHistoryEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(_directoryPath);
+            var entries = (await LoadHistoryUnsafeAsync(cancellationToken).ConfigureAwait(false)).ToList();
+            entries.RemoveAll(existing => existing.Id == entry.Id);
+            entries.Add(entry);
+            var ordered = entries
+                .OrderByDescending(item => item.CompletedAtUtc)
+                .Take(MaxHistoryEntries)
+                .ToArray();
+            await WriteAtomicAsync(_historyPath, ordered, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (File.Exists(_historyPath))
+            {
+                File.Delete(_historyPath);
+            }
+
+            if (File.Exists(_settingsPath))
+            {
+                File.Delete(_settingsPath);
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<IReadOnlyList<SetupHistoryEntry>> LoadHistoryUnsafeAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_historyPath))
+        {
+            return Array.Empty<SetupHistoryEntry>();
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(_historyPath);
+            return await JsonSerializer.DeserializeAsync<SetupHistoryEntry[]>(stream, _jsonOptions, cancellationToken)
+                .ConfigureAwait(false) ?? Array.Empty<SetupHistoryEntry>();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<SetupHistoryEntry>();
+        }
+    }
+
+    private async Task WriteAtomicAsync<T>(string path, T value, CancellationToken cancellationToken)
+    {
+        var tempPath = path + ".tmp";
+        await using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, 16_384, useAsync: true))
+        {
+            await JsonSerializer.SerializeAsync(stream, value, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        File.Move(tempPath, path, overwrite: true);
+    }
+}

--- a/src/AgenStart.Desktop/LocalData/LocalExperienceViewModel.cs
+++ b/src/AgenStart.Desktop/LocalData/LocalExperienceViewModel.cs
@@ -1,0 +1,210 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace AgenStart.Desktop.LocalData;
+
+public sealed class SetupHistoryRowViewModel
+{
+    public SetupHistoryRowViewModel(SetupHistoryEntry entry)
+    {
+        Entry = entry;
+    }
+
+    public SetupHistoryEntry Entry { get; }
+    public Guid Id => Entry.Id;
+    public string Profile => Entry.Profile;
+    public int ProcessedCount => Entry.ProcessedCount;
+    public int InstalledCount => Entry.InstalledCount;
+    public int AlreadyInstalledCount => Entry.AlreadyInstalledCount;
+    public int FailedCount => Entry.FailedCount;
+    public int SkippedCount => Entry.SkippedCount;
+    public int CancelledCount => Entry.CancelledCount;
+    public bool RequiresReboot => Entry.RequiresReboot;
+    public IReadOnlyList<SetupHistoryApplication> Applications => Entry.Applications;
+    public string CompletedAt => Entry.CompletedAtUtc.ToLocalTime().ToString("MMM d, yyyy · HH:mm");
+    public string Outcome => FailedCount > 0
+        ? $"Completed with {FailedCount} issue{(FailedCount == 1 ? string.Empty : "s")}"
+        : CancelledCount > 0
+            ? $"Cancelled · {CancelledCount} item{(CancelledCount == 1 ? string.Empty : "s")} not completed"
+            : SkippedCount > 0
+                ? $"Completed · {SkippedCount} skipped"
+                : "Completed successfully";
+    public string ApplicationSummary => $"{ProcessedCount} application{(ProcessedCount == 1 ? string.Empty : "s")} processed";
+}
+
+public sealed class LocalExperienceViewModel : INotifyPropertyChanged
+{
+    private readonly LocalExperienceStore _store;
+    private SetupHistoryRowViewModel? _selectedHistory;
+    private bool _analyzeOnStartup = true;
+    private bool _clearConfirmationVisible;
+    private string _storageStatus = "Stored only on this device.";
+    private bool _initialized;
+
+    public LocalExperienceViewModel(LocalExperienceStore? store = null)
+    {
+        _store = store ?? new LocalExperienceStore();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public ObservableCollection<SetupHistoryRowViewModel> HistoryEntries { get; } = [];
+
+    public SetupHistoryRowViewModel? SelectedHistory
+    {
+        get => _selectedHistory;
+        set => SetField(ref _selectedHistory, value);
+    }
+
+    public bool AnalyzeOnStartup
+    {
+        get => _analyzeOnStartup;
+        set
+        {
+            if (!SetField(ref _analyzeOnStartup, value))
+            {
+                return;
+            }
+
+            _ = SaveSettingsSafeAsync();
+        }
+    }
+
+    public bool ClearConfirmationVisible
+    {
+        get => _clearConfirmationVisible;
+        private set => SetField(ref _clearConfirmationVisible, value);
+    }
+
+    public string StorageStatus
+    {
+        get => _storageStatus;
+        private set => SetField(ref _storageStatus, value);
+    }
+
+    public bool HasHistory => HistoryEntries.Count > 0;
+    public bool TelemetryAvailable => false;
+    public bool ExportManagementAvailable => false;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        var settings = await _store.LoadSettingsAsync(cancellationToken).ConfigureAwait(true);
+        _analyzeOnStartup = settings.AnalyzeOnStartup;
+        OnPropertyChanged(nameof(AnalyzeOnStartup));
+        await ReloadHistoryAsync(cancellationToken).ConfigureAwait(true);
+        _initialized = true;
+    }
+
+    public async Task RecordSessionAsync(
+        Guid id,
+        string profile,
+        int processedCount,
+        int installedCount,
+        int alreadyInstalledCount,
+        int failedCount,
+        int skippedCount,
+        int cancelledCount,
+        bool requiresReboot,
+        IEnumerable<SetupHistoryApplication> applications,
+        CancellationToken cancellationToken = default)
+    {
+        var safeApplications = applications
+            .Where(item => !string.IsNullOrWhiteSpace(item.ApplicationId) && !string.IsNullOrWhiteSpace(item.Name))
+            .Select(item => item with
+            {
+                ApplicationId = item.ApplicationId.Trim(),
+                Name = item.Name.Trim(),
+                Result = item.Result.Trim(),
+                InstalledVersion = string.IsNullOrWhiteSpace(item.InstalledVersion) || item.InstalledVersion == "—"
+                    ? null
+                    : item.InstalledVersion.Trim()
+            })
+            .ToArray();
+
+        var entry = new SetupHistoryEntry(
+            id,
+            DateTimeOffset.UtcNow,
+            string.IsNullOrWhiteSpace(profile) ? "Unknown" : profile.Trim(),
+            processedCount,
+            installedCount,
+            alreadyInstalledCount,
+            failedCount,
+            skippedCount,
+            cancelledCount,
+            requiresReboot,
+            safeApplications);
+
+        await _store.UpsertHistoryAsync(entry, cancellationToken).ConfigureAwait(true);
+        await ReloadHistoryAsync(cancellationToken).ConfigureAwait(true);
+    }
+
+    public void BeginClearLocalData() => ClearConfirmationVisible = true;
+
+    public void CancelClearLocalData() => ClearConfirmationVisible = false;
+
+    public async Task ConfirmClearLocalDataAsync(CancellationToken cancellationToken = default)
+    {
+        await _store.ClearAsync(cancellationToken).ConfigureAwait(true);
+        HistoryEntries.Clear();
+        SelectedHistory = null;
+        _analyzeOnStartup = true;
+        OnPropertyChanged(nameof(AnalyzeOnStartup));
+        OnPropertyChanged(nameof(HasHistory));
+        ClearConfirmationVisible = false;
+        StorageStatus = "Local AgenStart history and preferences were cleared.";
+    }
+
+    private async Task ReloadHistoryAsync(CancellationToken cancellationToken)
+    {
+        var selectedId = SelectedHistory?.Id;
+        var entries = await _store.LoadHistoryAsync(cancellationToken).ConfigureAwait(true);
+        HistoryEntries.Clear();
+        foreach (var entry in entries.OrderByDescending(item => item.CompletedAtUtc))
+        {
+            HistoryEntries.Add(new SetupHistoryRowViewModel(entry));
+        }
+
+        SelectedHistory = selectedId is null
+            ? HistoryEntries.FirstOrDefault()
+            : HistoryEntries.FirstOrDefault(item => item.Id == selectedId) ?? HistoryEntries.FirstOrDefault();
+        OnPropertyChanged(nameof(HasHistory));
+    }
+
+    private async Task SaveSettingsSafeAsync()
+    {
+        try
+        {
+            await _store.SaveSettingsAsync(new DesktopSettings(AnalyzeOnStartup)).ConfigureAwait(false);
+            StorageStatus = "Preferences saved locally.";
+        }
+        catch (IOException)
+        {
+            StorageStatus = "AgenStart could not save the local preference.";
+        }
+        catch (UnauthorizedAccessException)
+        {
+            StorageStatus = "AgenStart does not have access to its local settings folder.";
+        }
+    }
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/src/AgenStart.Desktop/Views/HistoryView.axaml
+++ b/src/AgenStart.Desktop/Views/HistoryView.axaml
@@ -1,0 +1,84 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:AgenStart.Desktop.LocalData"
+             x:Class="AgenStart.Desktop.Views.HistoryView"
+             x:DataType="local:LocalExperienceViewModel">
+  <Grid MaxWidth="1160" HorizontalAlignment="Left">
+    <StackPanel>
+      <TextBlock Classes="eyebrow" Text="HISTORY" Margin="0,0,0,20" />
+      <TextBlock Classes="pageTitle" Text="Setup history" />
+      <TextBlock Classes="subtitle" Text="Previous AgenStart setup sessions stored locally on this device." Margin="0,12,0,0" />
+      <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,28,0,24" />
+
+      <Grid ColumnDefinitions="1.2*,0.8*" ColumnSpacing="48">
+        <StackPanel Grid.Column="0">
+          <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,10">
+            <TextBlock Text="Sessions" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock Grid.Column="1" Text="Local only" Foreground="{StaticResource AgenMutedBrush}" FontSize="13" VerticalAlignment="Center" />
+          </Grid>
+
+          <ListBox ItemsSource="{Binding HistoryEntries}" SelectedItem="{Binding SelectedHistory, Mode=TwoWay}" Background="Transparent" BorderThickness="0">
+            <ListBox.ItemTemplate>
+              <DataTemplate x:DataType="local:SetupHistoryRowViewModel">
+                <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="0,0,0,1" Padding="8,14">
+                  <Grid ColumnDefinitions="150,*,170" ColumnSpacing="18">
+                    <StackPanel>
+                      <TextBlock Text="{Binding CompletedAt}" FontWeight="SemiBold" />
+                      <TextBlock Text="{Binding Profile}" Foreground="{StaticResource AgenTealBrush}" FontSize="13" Margin="0,4,0,0" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="1">
+                      <TextBlock Text="{Binding ApplicationSummary}" FontSize="15" FontWeight="SemiBold" />
+                      <TextBlock Text="{Binding Outcome}" Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="2" HorizontalAlignment="Right">
+                      <TextBlock Text="{Binding InstalledCount, StringFormat='{}{0} installed'}" TextAlignment="Right" />
+                      <TextBlock Text="{Binding FailedCount, StringFormat='{}{0} failed'}" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" TextAlignment="Right" Margin="0,4,0,0" />
+                    </StackPanel>
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+
+          <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="1" CornerRadius="8" Padding="18" Margin="0,22,0,0">
+            <StackPanel Orientation="Horizontal" Spacing="12">
+              <TextBlock Text="↶" Foreground="{StaticResource AgenTealBrush}" FontSize="20" />
+              <StackPanel>
+                <TextBlock Text="No cloud history" FontWeight="SemiBold" />
+                <TextBlock Text="Session summaries stay in AgenStart's local application-data folder." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+              </StackPanel>
+            </StackPanel>
+          </Border>
+        </StackPanel>
+
+        <StackPanel Grid.Column="1" Spacing="14">
+          <TextBlock Text="Session details" FontSize="20" FontWeight="SemiBold" />
+          <Border BorderBrush="{StaticResource AgenDividerBrush}" BorderThickness="1" CornerRadius="8" Padding="20">
+            <StackPanel Spacing="12">
+              <TextBlock Text="{Binding SelectedHistory.Profile}" FontSize="24" FontWeight="SemiBold" />
+              <TextBlock Text="{Binding SelectedHistory.CompletedAt}" Foreground="{StaticResource AgenMutedBrush}" />
+              <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,4" />
+              <Grid ColumnDefinitions="*,*">
+                <StackPanel><TextBlock Text="{Binding SelectedHistory.ProcessedCount}" Foreground="{StaticResource AgenTealBrush}" FontSize="20" FontWeight="SemiBold" /><TextBlock Text="processed" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel>
+                <StackPanel Grid.Column="1"><TextBlock Text="{Binding SelectedHistory.FailedCount}" FontSize="20" FontWeight="SemiBold" /><TextBlock Text="failed" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" /></StackPanel>
+              </Grid>
+              <TextBlock Text="Applications" FontWeight="SemiBold" Margin="0,8,0,0" />
+              <ItemsControl ItemsSource="{Binding SelectedHistory.Applications}">
+                <ItemsControl.ItemTemplate>
+                  <DataTemplate x:DataType="local:SetupHistoryApplication">
+                    <Grid ColumnDefinitions="*,150" Margin="0,5">
+                      <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" />
+                      <TextBlock Grid.Column="1" Text="{Binding Result}" Foreground="{StaticResource AgenMutedBrush}" TextAlignment="Right" />
+                    </Grid>
+                  </DataTemplate>
+                </ItemsControl.ItemTemplate>
+              </ItemsControl>
+              <Button Classes="secondary" Content="Export setup" IsEnabled="{Binding ExportManagementAvailable}" Margin="0,10,0,0" />
+              <TextBlock Text="Reusable setup export arrives with milestone #9." Foreground="{StaticResource AgenMutedBrush}" FontSize="12" TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
+        </StackPanel>
+      </Grid>
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/src/AgenStart.Desktop/Views/HistoryView.axaml.cs
+++ b/src/AgenStart.Desktop/Views/HistoryView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace AgenStart.Desktop.Views;
+
+public sealed partial class HistoryView : UserControl
+{
+    public HistoryView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/AgenStart.Desktop/Views/MainWindow.axaml.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.axaml.cs
@@ -1,7 +1,10 @@
 using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
+using AgenStart.Application.Installation;
 using AgenStart.Core.Catalogue;
+using AgenStart.Desktop.LocalData;
 using AgenStart.Desktop.ViewModels;
 
 namespace AgenStart.Desktop.Views;
@@ -10,6 +13,12 @@ public sealed partial class MainWindow : Window
 {
     private readonly CancellationTokenSource _lifetimeCancellation = new();
     private readonly MainWindowViewModel _viewModel;
+    private readonly LocalExperienceViewModel _localExperience = new();
+    private HistoryView? _historyView;
+    private SettingsView? _settingsView;
+    private Button? _historyButton;
+    private Button? _settingsButton;
+    private Guid? _currentHistoryEntryId;
 
     public MainWindow()
     {
@@ -25,7 +34,10 @@ public sealed partial class MainWindow : Window
         InstallationButton.IsEnabled = false;
         ReportButton.IsEnabled = false;
 
+        InstallUtilityViews();
+
         _viewModel.PropertyChanged += ViewModel_OnPropertyChanged;
+        Opened += OnOpened;
         Closed += OnClosed;
     }
 
@@ -37,14 +49,31 @@ public sealed partial class MainWindow : Window
     private void InstallationButton_OnClick(object? sender, RoutedEventArgs e) => ShowInstallation();
     private void ReportButton_OnClick(object? sender, RoutedEventArgs e) => ShowReport();
 
+    private async void OnOpened(object? sender, EventArgs e)
+    {
+        try
+        {
+            await _localExperience.InitializeAsync(_lifetimeCancellation.Token);
+            if (_localExperience.AnalyzeOnStartup && !_viewModel.HasSnapshot)
+            {
+                await _viewModel.AnalyzeAsync(_lifetimeCancellation.Token);
+                if (_viewModel.HasSnapshot)
+                {
+                    EnablePostAnalysisNavigation();
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)
+        {
+        }
+    }
+
     private async void AnalyzeButton_OnClick(object? sender, RoutedEventArgs e)
     {
         await _viewModel.AnalyzeAsync(_lifetimeCancellation.Token);
         if (_viewModel.HasSnapshot)
         {
-            YourPcButton.IsEnabled = true;
-            UsageProfileButton.IsEnabled = true;
-            RecommendationsButton.IsEnabled = false;
+            EnablePostAnalysisNavigation();
             ShowYourPc();
         }
     }
@@ -54,9 +83,15 @@ public sealed partial class MainWindow : Window
         await _viewModel.AnalyzeAsync(_lifetimeCancellation.Token);
         if (_viewModel.HasSnapshot)
         {
-            UsageProfileButton.IsEnabled = true;
-            RecommendationsButton.IsEnabled = false;
+            EnablePostAnalysisNavigation();
         }
+    }
+
+    private void EnablePostAnalysisNavigation()
+    {
+        YourPcButton.IsEnabled = true;
+        UsageProfileButton.IsEnabled = true;
+        RecommendationsButton.IsEnabled = false;
     }
 
     private void ContinueToProfile_OnClick(object? sender, RoutedEventArgs e) => ShowUsageProfile();
@@ -118,12 +153,14 @@ public sealed partial class MainWindow : Window
             return;
         }
 
+        _currentHistoryEntryId = Guid.NewGuid();
         InstallationButton.IsEnabled = true;
         ShowInstallation();
         await _viewModel.StartInstallationAsync(_lifetimeCancellation.Token);
 
         if (_viewModel.HasReport)
         {
+            await PersistCurrentReportAsync();
             ReportButton.IsEnabled = true;
             if (_viewModel.InstallationFailedCount == 0)
             {
@@ -145,6 +182,8 @@ public sealed partial class MainWindow : Window
         await _viewModel.RetryInstallationAsync(row.ApplicationId, _lifetimeCancellation.Token);
         if (_viewModel.HasReport)
         {
+            _currentHistoryEntryId ??= Guid.NewGuid();
+            await PersistCurrentReportAsync();
             ReportButton.IsEnabled = true;
             if (_viewModel.InstallationFailedCount == 0)
             {
@@ -153,8 +192,108 @@ public sealed partial class MainWindow : Window
         }
     }
 
+    private async Task PersistCurrentReportAsync()
+    {
+        if (!_viewModel.HasReport || _currentHistoryEntryId is null)
+        {
+            return;
+        }
+
+        var applications = _viewModel.ReportItems.Select(row => new SetupHistoryApplication(
+            row.ApplicationId,
+            row.Name,
+            row.Result,
+            row.InstalledVersion));
+        var skippedCount = _viewModel.InstallationItems.Count(row => row.State == InstallationQueueItemState.Skipped);
+        var cancelledCount = _viewModel.InstallationItems.Count(row => row.State == InstallationQueueItemState.Cancelled);
+
+        try
+        {
+            await _localExperience.RecordSessionAsync(
+                _currentHistoryEntryId.Value,
+                _viewModel.SelectedProfileName,
+                _viewModel.ReportProcessedCount,
+                _viewModel.ReportInstalledCount,
+                _viewModel.ReportAlreadyInstalledCount,
+                _viewModel.ReportFailedCount,
+                skippedCount,
+                cancelledCount,
+                _viewModel.ReportRequiresReboot,
+                applications,
+                _lifetimeCancellation.Token);
+        }
+        catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)
+        {
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
     private void ViewReportButton_OnClick(object? sender, RoutedEventArgs e) => ShowReport();
     private void FinishButton_OnClick(object? sender, RoutedEventArgs e) => ShowOverview();
+
+    private void InstallUtilityViews()
+    {
+        if (OverviewPanel.Parent is not Grid pageHost)
+        {
+            return;
+        }
+
+        _historyView = new HistoryView
+        {
+            DataContext = _localExperience,
+            IsVisible = false
+        };
+        _settingsView = new SettingsView
+        {
+            DataContext = _localExperience,
+            IsVisible = false
+        };
+        pageHost.Children.Add(_historyView);
+        pageHost.Children.Add(_settingsView);
+
+        _historyButton = FindNavigationButton("History");
+        _settingsButton = FindNavigationButton("Settings");
+
+        if (_historyButton is not null)
+        {
+            _historyButton.IsEnabled = true;
+            _historyButton.Click += HistoryButton_OnClick;
+        }
+
+        if (_settingsButton is not null)
+        {
+            _settingsButton.IsEnabled = true;
+            _settingsButton.Click += SettingsButton_OnClick;
+        }
+    }
+
+    private Button? FindNavigationButton(string label) =>
+        this.GetLogicalDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(button => button.GetLogicalDescendants()
+                .OfType<TextBlock>()
+                .Any(text => string.Equals(text.Text, label, StringComparison.Ordinal)));
+
+    private void HistoryButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_historyView is not null && _historyButton is not null)
+        {
+            ShowUtilityPage(_historyView, _historyButton);
+        }
+    }
+
+    private void SettingsButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_settingsView is not null && _settingsButton is not null)
+        {
+            ShowUtilityPage(_settingsView, _settingsButton);
+        }
+    }
 
     private void ShowOverview() => ShowPage(OverviewPanel, OverviewButton, OverviewStripe);
 
@@ -208,29 +347,60 @@ public sealed partial class MainWindow : Window
 
     private void ShowPage(Control panel, Button activeButton, Border activeStripe)
     {
-        OverviewPanel.IsVisible = ReferenceEquals(panel, OverviewPanel);
-        YourPcPanel.IsVisible = ReferenceEquals(panel, YourPcPanel);
-        UsageProfilePanel.IsVisible = ReferenceEquals(panel, UsageProfilePanel);
-        RecommendationsPanel.IsVisible = ReferenceEquals(panel, RecommendationsPanel);
-        ReviewPanel.IsVisible = ReferenceEquals(panel, ReviewPanel);
-        InstallationPanel.IsVisible = ReferenceEquals(panel, InstallationPanel);
-        ReportPanel.IsVisible = ReferenceEquals(panel, ReportPanel);
+        HideAllPages();
+        panel.IsVisible = true;
+        activeStripe.IsVisible = true;
+        SetActive(activeButton, true);
+    }
 
-        OverviewStripe.IsVisible = ReferenceEquals(activeStripe, OverviewStripe);
-        YourPcStripe.IsVisible = ReferenceEquals(activeStripe, YourPcStripe);
-        UsageProfileStripe.IsVisible = ReferenceEquals(activeStripe, UsageProfileStripe);
-        RecommendationsStripe.IsVisible = ReferenceEquals(activeStripe, RecommendationsStripe);
-        ReviewStripe.IsVisible = ReferenceEquals(activeStripe, ReviewStripe);
-        InstallationStripe.IsVisible = ReferenceEquals(activeStripe, InstallationStripe);
-        ReportStripe.IsVisible = ReferenceEquals(activeStripe, ReportStripe);
+    private void ShowUtilityPage(Control panel, Button activeButton)
+    {
+        HideAllPages();
+        panel.IsVisible = true;
+        SetActive(activeButton, true);
+    }
 
-        SetActive(OverviewButton, ReferenceEquals(activeButton, OverviewButton));
-        SetActive(YourPcButton, ReferenceEquals(activeButton, YourPcButton));
-        SetActive(UsageProfileButton, ReferenceEquals(activeButton, UsageProfileButton));
-        SetActive(RecommendationsButton, ReferenceEquals(activeButton, RecommendationsButton));
-        SetActive(ReviewButton, ReferenceEquals(activeButton, ReviewButton));
-        SetActive(InstallationButton, ReferenceEquals(activeButton, InstallationButton));
-        SetActive(ReportButton, ReferenceEquals(activeButton, ReportButton));
+    private void HideAllPages()
+    {
+        OverviewPanel.IsVisible = false;
+        YourPcPanel.IsVisible = false;
+        UsageProfilePanel.IsVisible = false;
+        RecommendationsPanel.IsVisible = false;
+        ReviewPanel.IsVisible = false;
+        InstallationPanel.IsVisible = false;
+        ReportPanel.IsVisible = false;
+        if (_historyView is not null)
+        {
+            _historyView.IsVisible = false;
+        }
+        if (_settingsView is not null)
+        {
+            _settingsView.IsVisible = false;
+        }
+
+        OverviewStripe.IsVisible = false;
+        YourPcStripe.IsVisible = false;
+        UsageProfileStripe.IsVisible = false;
+        RecommendationsStripe.IsVisible = false;
+        ReviewStripe.IsVisible = false;
+        InstallationStripe.IsVisible = false;
+        ReportStripe.IsVisible = false;
+
+        SetActive(OverviewButton, false);
+        SetActive(YourPcButton, false);
+        SetActive(UsageProfileButton, false);
+        SetActive(RecommendationsButton, false);
+        SetActive(ReviewButton, false);
+        SetActive(InstallationButton, false);
+        SetActive(ReportButton, false);
+        if (_historyButton is not null)
+        {
+            SetActive(_historyButton, false);
+        }
+        if (_settingsButton is not null)
+        {
+            SetActive(_settingsButton, false);
+        }
     }
 
     private void ViewModel_OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -270,6 +440,15 @@ public sealed partial class MainWindow : Window
     private void OnClosed(object? sender, EventArgs e)
     {
         _viewModel.PropertyChanged -= ViewModel_OnPropertyChanged;
+        if (_historyButton is not null)
+        {
+            _historyButton.Click -= HistoryButton_OnClick;
+        }
+        if (_settingsButton is not null)
+        {
+            _settingsButton.Click -= SettingsButton_OnClick;
+        }
+        Opened -= OnOpened;
         _lifetimeCancellation.Cancel();
         _viewModel.Dispose();
         _lifetimeCancellation.Dispose();

--- a/src/AgenStart.Desktop/Views/SettingsView.axaml
+++ b/src/AgenStart.Desktop/Views/SettingsView.axaml
@@ -1,0 +1,111 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:AgenStart.Desktop.LocalData"
+             x:Class="AgenStart.Desktop.Views.SettingsView"
+             x:DataType="local:LocalExperienceViewModel">
+  <Grid MaxWidth="1040" HorizontalAlignment="Left">
+    <StackPanel>
+      <TextBlock Classes="eyebrow" Text="SETTINGS" Margin="0,0,0,20" />
+      <TextBlock Classes="pageTitle" Text="Settings" />
+      <TextBlock Classes="subtitle" Text="Control how AgenStart behaves on this device." Margin="0,12,0,0" />
+      <Border Height="1" Background="{StaticResource AgenDividerBrush}" Margin="0,28,0,26" />
+
+      <TextBlock Text="General" FontSize="20" FontWeight="SemiBold" />
+      <Border Classes="dataRow" Margin="0,8,0,0">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="30">
+          <StackPanel>
+            <TextBlock Text="Analyse this PC when AgenStart starts" FontSize="16" FontWeight="SemiBold" />
+            <TextBlock Text="Runs the same read-only local capability scan used by Your PC." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+          </StackPanel>
+          <CheckBox Grid.Column="1" IsChecked="{Binding AnalyzeOnStartup, Mode=TwoWay}" VerticalAlignment="Center" />
+        </Grid>
+      </Border>
+      <Border Classes="dataRow">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="30">
+          <StackPanel>
+            <TextBlock Text="Theme" FontSize="16" FontWeight="SemiBold" />
+            <TextBlock Text="AgenStart currently follows the system theme baseline." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+          </StackPanel>
+          <TextBlock Grid.Column="1" Text="System" Foreground="{StaticResource AgenMutedBrush}" VerticalAlignment="Center" />
+        </Grid>
+      </Border>
+
+      <TextBlock Text="Installation" FontSize="20" FontWeight="SemiBold" Margin="0,28,0,0" />
+      <Border Classes="dataRow" Margin="0,8,0,0">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="30">
+          <StackPanel>
+            <TextBlock Text="Package provider" FontSize="16" FontWeight="SemiBold" />
+            <TextBlock Text="Exact catalogue package identities are resolved through WinGet." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+          </StackPanel>
+          <TextBlock Grid.Column="1" Text="WinGet" Foreground="{StaticResource AgenTealBrush}" FontWeight="SemiBold" VerticalAlignment="Center" />
+        </Grid>
+      </Border>
+      <Border Classes="dataRow">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="30">
+          <StackPanel>
+            <TextBlock Text="Package agreements" FontSize="16" FontWeight="SemiBold" />
+            <TextBlock Text="AgenStart requires explicit approval on the Review screen before accepting provider agreements." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+          </StackPanel>
+          <TextBlock Grid.Column="1" Text="Required" Foreground="{StaticResource AgenMutedBrush}" VerticalAlignment="Center" />
+        </Grid>
+      </Border>
+
+      <TextBlock Text="Privacy" FontSize="20" FontWeight="SemiBold" Margin="0,28,0,0" />
+      <Border Classes="dataRow" Margin="0,8,0,0">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="30">
+          <StackPanel>
+            <TextBlock Text="Anonymous product analytics" FontSize="16" FontWeight="SemiBold" />
+            <TextBlock Text="Not available yet. No telemetry is sent by this build. Privacy-first telemetry is tracked in #15." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" TextWrapping="Wrap" />
+          </StackPanel>
+          <CheckBox Grid.Column="1" IsChecked="False" IsEnabled="{Binding TelemetryAvailable}" VerticalAlignment="Center" />
+        </Grid>
+      </Border>
+      <Border Classes="dataRow">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="30">
+          <StackPanel>
+            <TextBlock Text="Local AgenStart data" FontSize="16" FontWeight="SemiBold" />
+            <TextBlock Text="History and preferences are stored only in AgenStart's local application-data folder." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+          </StackPanel>
+          <Button Grid.Column="1" Classes="secondary" Content="Clear local data" Click="ClearLocalDataButton_OnClick" />
+        </Grid>
+      </Border>
+
+      <Border IsVisible="{Binding ClearConfirmationVisible}" BorderBrush="#AAB2B2" BorderThickness="1" CornerRadius="8" Padding="18" Margin="0,14,0,0">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="24">
+          <StackPanel>
+            <TextBlock Text="Clear local AgenStart data?" FontWeight="SemiBold" />
+            <TextBlock Text="This removes setup history and resets local preferences. Installed applications are not touched." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+          </StackPanel>
+          <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+            <Button Classes="secondary" Content="Cancel" Click="CancelClearButton_OnClick" />
+            <Button Classes="primary" Content="Clear" Click="ConfirmClearButton_OnClick" />
+          </StackPanel>
+        </Grid>
+      </Border>
+      <TextBlock Text="{Binding StorageStatus}" Foreground="{StaticResource AgenMutedBrush}" FontSize="12" Margin="0,10,0,0" />
+
+      <TextBlock Text="Setup profiles" FontSize="20" FontWeight="SemiBold" Margin="0,28,0,0" />
+      <Border Classes="dataRow" Margin="0,8,0,0">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="30">
+          <StackPanel>
+            <TextBlock Text="Manage exported setups" FontSize="16" FontWeight="SemiBold" />
+            <TextBlock Text="Reusable import/export profiles will be enabled by milestone #9." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+          </StackPanel>
+          <Button Grid.Column="1" Classes="secondary" Content="Manage" IsEnabled="{Binding ExportManagementAvailable}" />
+        </Grid>
+      </Border>
+
+      <TextBlock Text="About" FontSize="20" FontWeight="SemiBold" Margin="0,28,0,0" />
+      <Border Classes="dataRow" Margin="0,8,0,0">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="30">
+          <StackPanel>
+            <TextBlock Text="AgenStart" FontSize="17" FontWeight="SemiBold" />
+            <TextBlock Text="0.1.0-alpha · BY AGENSTUDIO" Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,4,0,0" />
+            <TextBlock Text="Think sharp. Build what matters." Foreground="{StaticResource AgenMutedBrush}" FontSize="13" Margin="0,3,0,0" />
+          </StackPanel>
+          <TextBlock Grid.Column="1" Text="Local-first" Foreground="{StaticResource AgenTealBrush}" FontWeight="SemiBold" VerticalAlignment="Center" />
+        </Grid>
+      </Border>
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/src/AgenStart.Desktop/Views/SettingsView.axaml.cs
+++ b/src/AgenStart.Desktop/Views/SettingsView.axaml.cs
@@ -1,0 +1,37 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using AgenStart.Desktop.LocalData;
+
+namespace AgenStart.Desktop.Views;
+
+public sealed partial class SettingsView : UserControl
+{
+    public SettingsView()
+    {
+        InitializeComponent();
+    }
+
+    private void ClearLocalDataButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is LocalExperienceViewModel viewModel)
+        {
+            viewModel.BeginClearLocalData();
+        }
+    }
+
+    private void CancelClearButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is LocalExperienceViewModel viewModel)
+        {
+            viewModel.CancelClearLocalData();
+        }
+    }
+
+    private async void ConfirmClearButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is LocalExperienceViewModel viewModel)
+        {
+            await viewModel.ConfirmClearLocalDataAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the approved History and Settings experience for AgenStart while keeping data local-first and privacy-safe.

### History
- persists minimal setup-session summaries in the user's local application-data folder
- upserts the current session after installation/retry instead of duplicating it
- stores profile, application outcomes, counts, reboot requirement and installed versions only
- does not persist hostname, serial numbers, MAC addresses, usernames, personal files or machine fingerprints
- renders the approved chronological History screen with a session detail panel

### Settings
- persists `Analyse this PC when AgenStart starts` locally
- performs the existing read-only machine scan automatically when enabled
- keeps package-agreement approval mandatory on Review
- shows telemetry as unavailable until #15 is implemented; this build sends no telemetry
- keeps exported-setup management disabled until #9
- supports explicit two-step clearing of local history/preferences

### Desktop integration
- reuses the existing shell without changing the main XAML navigation markup
- activates History and Settings utility navigation at runtime
- keeps all existing guided workflow states intact

Closes #35.
Related to #8, #9 and #15.