### PR TITLE
feat: add versioned reproducible setup profile core

### DIFF
--- a/docs/product/setup-profile.md
+++ b/docs/product/setup-profile.md
@@ -1,0 +1,113 @@
+# Reproducible setup profile format
+
+AgenStart setup profiles are portable, reviewable JSON documents that describe the **desired application set**, not a copy of a machine.
+
+The current format is `agenstart.setup` schema version `1`.
+
+## Design goals
+
+- portable across compatible AgenStart installations;
+- based on canonical AgenStart application IDs rather than machine-specific package state;
+- safe to inspect before execution;
+- strict validation before any installation planning;
+- no hostname, username, serial number, MAC address, file path, account identity, hardware fingerprint or other sensitive machine identifier;
+- current installed-software state is always re-evaluated on the destination machine;
+- import never bypasses Review or installation approval.
+
+## Example
+
+```json
+{
+  "kind": "agenstart.setup",
+  "schemaVersion": 1,
+  "createdAtUtc": "2026-09-04T12:00:00+00:00",
+  "profileId": "development",
+  "applications": [
+    {
+      "applicationId": "git",
+      "reason": "Essential for source control."
+    },
+    {
+      "applicationId": "visual-studio-code",
+      "reason": "Recommended for development."
+    }
+  ],
+  "metadata": {
+    "name": "Development setup",
+    "agenStartVersion": "0.1.0-alpha"
+  }
+}
+```
+
+## Import pipeline
+
+```text
+setup JSON
+    │
+    ▼
+strict JSON parser
+    │
+    ▼
+schema/version validation
+    │
+    ▼
+canonical application IDs
+    │
+    ▼
+current AgenStart catalogue
+    │
+    ├── unknown/unsupported IDs → actionable validation result
+    │
+    ▼
+installed-software inventory on destination PC
+    │
+    ▼
+desired vs current comparison
+    │
+    ├── already installed → visible, skipped
+    │
+    └── missing + supported → proposed for installation
+    │
+    ▼
+Review screen
+    │
+    ▼
+explicit user approval
+```
+
+The imported file therefore never contains executable commands or arbitrary provider arguments. Package-provider identities are resolved from the destination machine's trusted AgenStart catalogue.
+
+## Validation rules
+
+- maximum document size: 256 KB;
+- `kind` must be `agenstart.setup`;
+- only schema version `1` is accepted by the current implementation;
+- at least one and at most 200 applications;
+- canonical application IDs must be lowercase portable identifiers and unique case-insensitively;
+- unknown JSON fields are rejected rather than silently ignored;
+- recommendation context is optional and capped at 512 characters;
+- malformed, corrupted or unsupported documents produce validation errors and cannot proceed to installation.
+
+JSON Schema: [`setup-profile.schema.json`](./setup-profile.schema.json).
+
+## Privacy boundary
+
+The setup profile contract intentionally has no field for machine inventory. Do not add fields for:
+
+- hostname/device name;
+- username or account identity;
+- serial numbers;
+- MAC addresses;
+- disk/BIOS identifiers;
+- personal file names or paths;
+- full environment or process lists;
+- credentials, tokens or secrets;
+- hardware-derived fingerprints.
+
+If recommendation context later needs capability information, it must use coarse, non-identifying categories and receive a separate privacy review.
+
+## Versioning
+
+`schemaVersion` is mandatory. Unsupported future versions fail closed with a clear diagnostic instead of being interpreted as version 1.
+
+A future schema version must document migration/compatibility behavior before it is accepted by the importer.

--- a/docs/product/setup-profile.schema.json
+++ b/docs/product/setup-profile.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:agenstart:setup-profile:v1",
+  "title": "AgenStart setup profile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "schemaVersion",
+    "createdAtUtc",
+    "profileId",
+    "applications"
+  ],
+  "properties": {
+    "kind": {
+      "const": "agenstart.setup"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "createdAtUtc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "profileId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,99}$"
+    },
+    "applications": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 200,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["applicationId"],
+        "properties": {
+          "applicationId": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]{0,99}$"
+          },
+          "reason": {
+            "type": "string",
+            "maxLength": 512
+          }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "agenStartVersion": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        }
+      }
+    }
+  }
+}

--- a/src/AgenStart.Application/Profiles/SetupProfileContracts.cs
+++ b/src/AgenStart.Application/Profiles/SetupProfileContracts.cs
@@ -1,0 +1,52 @@
+namespace AgenStart.Application.Profiles;
+
+public sealed record SetupProfileApplication(
+    string ApplicationId,
+    string? Reason = null);
+
+public sealed record SetupProfileMetadata(
+    string? Name = null,
+    string? AgenStartVersion = null);
+
+public sealed record SetupProfileDocument(
+    string Kind,
+    int SchemaVersion,
+    DateTimeOffset CreatedAtUtc,
+    string ProfileId,
+    IReadOnlyList<SetupProfileApplication> Applications,
+    SetupProfileMetadata? Metadata = null)
+{
+    public const string CurrentKind = "agenstart.setup";
+    public const int CurrentSchemaVersion = 1;
+}
+
+public sealed record SetupProfileValidationError(
+    string Code,
+    string Message,
+    string? Path = null);
+
+public sealed record SetupProfileReadResult(
+    bool IsValid,
+    SetupProfileDocument? Profile,
+    IReadOnlyList<SetupProfileValidationError> Errors)
+{
+    public static SetupProfileReadResult Valid(SetupProfileDocument profile) =>
+        new(true, profile, Array.Empty<SetupProfileValidationError>());
+
+    public static SetupProfileReadResult Invalid(params SetupProfileValidationError[] errors) =>
+        new(false, null, errors);
+
+    public static SetupProfileReadResult Invalid(IReadOnlyList<SetupProfileValidationError> errors) =>
+        new(false, null, errors);
+}
+
+public sealed class SetupProfileValidationException : Exception
+{
+    public SetupProfileValidationException(IReadOnlyList<SetupProfileValidationError> errors)
+        : base("The AgenStart setup profile is invalid.")
+    {
+        Errors = errors;
+    }
+
+    public IReadOnlyList<SetupProfileValidationError> Errors { get; }
+}

--- a/src/AgenStart.Application/Profiles/SetupProfileSerializer.cs
+++ b/src/AgenStart.Application/Profiles/SetupProfileSerializer.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AgenStart.Application.Profiles;
+
+public sealed class SetupProfileSerializer
+{
+    public const int MaxDocumentBytes = 256 * 1024;
+
+    private readonly SetupProfileValidator _validator;
+    private readonly JsonSerializerOptions _options;
+
+    public SetupProfileSerializer(SetupProfileValidator? validator = null)
+    {
+        _validator = validator ?? new SetupProfileValidator();
+        _options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true,
+            PropertyNameCaseInsensitive = false,
+            AllowTrailingCommas = false,
+            ReadCommentHandling = JsonCommentHandling.Disallow,
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+    }
+
+    public string Serialize(SetupProfileDocument profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        var errors = _validator.Validate(profile);
+        if (errors.Count > 0)
+        {
+            throw new SetupProfileValidationException(errors);
+        }
+
+        return JsonSerializer.Serialize(profile, _options);
+    }
+
+    public SetupProfileReadResult Deserialize(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return SetupProfileReadResult.Invalid(new SetupProfileValidationError(
+                "profile.document.empty",
+                "The setup profile file is empty."));
+        }
+
+        if (Encoding.UTF8.GetByteCount(json) > MaxDocumentBytes)
+        {
+            return SetupProfileReadResult.Invalid(new SetupProfileValidationError(
+                "profile.document.too_large",
+                $"The setup profile exceeds the {MaxDocumentBytes / 1024} KB safety limit."));
+        }
+
+        SetupProfileDocument? profile;
+        try
+        {
+            profile = JsonSerializer.Deserialize<SetupProfileDocument>(json, _options);
+        }
+        catch (JsonException)
+        {
+            return SetupProfileReadResult.Invalid(new SetupProfileValidationError(
+                "profile.document.invalid_json",
+                "The setup profile is malformed or contains unsupported fields."));
+        }
+        catch (NotSupportedException)
+        {
+            return SetupProfileReadResult.Invalid(new SetupProfileValidationError(
+                "profile.document.unsupported",
+                "The setup profile contains a value that this AgenStart build cannot read."));
+        }
+
+        var errors = _validator.Validate(profile);
+        return errors.Count == 0 && profile is not null
+            ? SetupProfileReadResult.Valid(profile)
+            : SetupProfileReadResult.Invalid(errors);
+    }
+}

--- a/src/AgenStart.Application/Profiles/SetupProfileValidator.cs
+++ b/src/AgenStart.Application/Profiles/SetupProfileValidator.cs
@@ -1,0 +1,138 @@
+using System.Text.RegularExpressions;
+
+namespace AgenStart.Application.Profiles;
+
+public sealed partial class SetupProfileValidator
+{
+    public const int MaxApplications = 200;
+    public const int MaxReasonLength = 512;
+    public const int MaxProfileNameLength = 100;
+    public const int MaxVersionLength = 64;
+
+    public IReadOnlyList<SetupProfileValidationError> Validate(SetupProfileDocument? profile)
+    {
+        if (profile is null)
+        {
+            return [new SetupProfileValidationError(
+                "profile.missing",
+                "The setup profile document is missing.")];
+        }
+
+        var errors = new List<SetupProfileValidationError>();
+
+        if (!string.Equals(profile.Kind, SetupProfileDocument.CurrentKind, StringComparison.Ordinal))
+        {
+            errors.Add(new SetupProfileValidationError(
+                "profile.kind.unsupported",
+                $"Expected kind '{SetupProfileDocument.CurrentKind}'.",
+                "kind"));
+        }
+
+        if (profile.SchemaVersion != SetupProfileDocument.CurrentSchemaVersion)
+        {
+            errors.Add(new SetupProfileValidationError(
+                "profile.schema.unsupported",
+                $"Schema version {profile.SchemaVersion} is not supported by this AgenStart build.",
+                "schemaVersion"));
+        }
+
+        if (profile.CreatedAtUtc == default)
+        {
+            errors.Add(new SetupProfileValidationError(
+                "profile.created_at.invalid",
+                "createdAtUtc must be a valid timestamp.",
+                "createdAtUtc"));
+        }
+
+        if (string.IsNullOrWhiteSpace(profile.ProfileId) || !PortableIdPattern().IsMatch(profile.ProfileId))
+        {
+            errors.Add(new SetupProfileValidationError(
+                "profile.profile_id.invalid",
+                "profileId must be a portable lowercase identifier using letters, digits, dots, underscores or hyphens.",
+                "profileId"));
+        }
+
+        if (profile.Applications is null || profile.Applications.Count == 0)
+        {
+            errors.Add(new SetupProfileValidationError(
+                "profile.applications.empty",
+                "A setup profile must contain at least one application.",
+                "applications"));
+        }
+        else if (profile.Applications.Count > MaxApplications)
+        {
+            errors.Add(new SetupProfileValidationError(
+                "profile.applications.too_many",
+                $"A setup profile can contain at most {MaxApplications} applications.",
+                "applications"));
+        }
+
+        if (profile.Applications is not null)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 0; index < profile.Applications.Count; index++)
+            {
+                var application = profile.Applications[index];
+                var path = $"applications[{index}]";
+                if (application is null)
+                {
+                    errors.Add(new SetupProfileValidationError(
+                        "profile.application.missing",
+                        "Application entries cannot be null.",
+                        path));
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(application.ApplicationId) ||
+                    !PortableIdPattern().IsMatch(application.ApplicationId))
+                {
+                    errors.Add(new SetupProfileValidationError(
+                        "profile.application_id.invalid",
+                        "applicationId must be a portable canonical AgenStart application identifier.",
+                        path + ".applicationId"));
+                }
+                else if (!seen.Add(application.ApplicationId))
+                {
+                    errors.Add(new SetupProfileValidationError(
+                        "profile.application_id.duplicate",
+                        $"Application '{application.ApplicationId}' appears more than once.",
+                        path + ".applicationId"));
+                }
+
+                if (application.Reason is { Length: > MaxReasonLength })
+                {
+                    errors.Add(new SetupProfileValidationError(
+                        "profile.reason.too_long",
+                        $"Recommendation context cannot exceed {MaxReasonLength} characters.",
+                        path + ".reason"));
+                }
+            }
+        }
+
+        if (profile.Metadata is not null)
+        {
+            if (profile.Metadata.Name is { } name &&
+                (string.IsNullOrWhiteSpace(name) || name.Length > MaxProfileNameLength))
+            {
+                errors.Add(new SetupProfileValidationError(
+                    "profile.metadata.name.invalid",
+                    $"Profile name must be between 1 and {MaxProfileNameLength} characters when provided.",
+                    "metadata.name"));
+            }
+
+            if (profile.Metadata.AgenStartVersion is { } version &&
+                (string.IsNullOrWhiteSpace(version) || version.Length > MaxVersionLength))
+            {
+                errors.Add(new SetupProfileValidationError(
+                    "profile.metadata.version.invalid",
+                    $"AgenStart version cannot exceed {MaxVersionLength} characters.",
+                    "metadata.agenStartVersion"));
+            }
+        }
+
+        return errors;
+    }
+
+    [GeneratedRegex("^[a-z0-9][a-z0-9._-]{0,99}$", RegexOptions.CultureInvariant)]
+    private static partial Regex PortableIdPattern();
+}

--- a/tests/AgenStart.Application.Tests/SetupProfileSerializerTests.cs
+++ b/tests/AgenStart.Application.Tests/SetupProfileSerializerTests.cs
@@ -1,0 +1,127 @@
+using AgenStart.Application.Profiles;
+
+namespace AgenStart.Application.Tests;
+
+public sealed class SetupProfileSerializerTests
+{
+    private readonly SetupProfileSerializer _serializer = new();
+
+    [Fact]
+    public void SerializeAndDeserialize_RoundTripsPortableSetupProfile()
+    {
+        var profile = new SetupProfileDocument(
+            SetupProfileDocument.CurrentKind,
+            SetupProfileDocument.CurrentSchemaVersion,
+            new DateTimeOffset(2026, 9, 4, 12, 0, 0, TimeSpan.Zero),
+            "development",
+            [
+                new SetupProfileApplication("git", "Essential for source control."),
+                new SetupProfileApplication("visual-studio-code", "Recommended for development."),
+                new SetupProfileApplication("7zip")
+            ],
+            new SetupProfileMetadata("Development setup", "0.1.0-alpha"));
+
+        var json = _serializer.Serialize(profile);
+        var result = _serializer.Deserialize(json);
+
+        Assert.True(result.IsValid);
+        Assert.NotNull(result.Profile);
+        Assert.Equal("development", result.Profile.ProfileId);
+        Assert.Equal(3, result.Profile.Applications.Count);
+        Assert.Equal("git", result.Profile.Applications[0].ApplicationId);
+        Assert.Equal("Development setup", result.Profile.Metadata?.Name);
+        Assert.False(json.Contains("hostname", StringComparison.OrdinalIgnoreCase));
+        Assert.False(json.Contains("serial", StringComparison.OrdinalIgnoreCase));
+        Assert.False(json.Contains("macAddress", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Deserialize_RejectsUnsupportedSchemaVersion()
+    {
+        const string json = """
+        {
+          "kind": "agenstart.setup",
+          "schemaVersion": 99,
+          "createdAtUtc": "2026-09-04T12:00:00+00:00",
+          "profileId": "development",
+          "applications": [
+            { "applicationId": "git" }
+          ]
+        }
+        """;
+
+        var result = _serializer.Deserialize(json);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Code == "profile.schema.unsupported");
+    }
+
+    [Fact]
+    public void Deserialize_RejectsDuplicateCanonicalApplicationIds()
+    {
+        const string json = """
+        {
+          "kind": "agenstart.setup",
+          "schemaVersion": 1,
+          "createdAtUtc": "2026-09-04T12:00:00+00:00",
+          "profileId": "development",
+          "applications": [
+            { "applicationId": "git" },
+            { "applicationId": "Git" }
+          ]
+        }
+        """;
+
+        var result = _serializer.Deserialize(json);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Code == "profile.application_id.duplicate");
+    }
+
+    [Fact]
+    public void Deserialize_RejectsUnknownFieldsInsteadOfIgnoringThem()
+    {
+        const string json = """
+        {
+          "kind": "agenstart.setup",
+          "schemaVersion": 1,
+          "createdAtUtc": "2026-09-04T12:00:00+00:00",
+          "profileId": "development",
+          "applications": [
+            { "applicationId": "git" }
+          ],
+          "hostname": "should-never-be-accepted"
+        }
+        """;
+
+        var result = _serializer.Deserialize(json);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Code == "profile.document.invalid_json");
+    }
+
+    [Fact]
+    public void Deserialize_RejectsMalformedJsonCleanly()
+    {
+        var result = _serializer.Deserialize("{ not-valid-json");
+
+        Assert.False(result.IsValid);
+        Assert.Null(result.Profile);
+        Assert.Contains(result.Errors, error => error.Code == "profile.document.invalid_json");
+    }
+
+    [Fact]
+    public void Serialize_RejectsEmptyApplicationSelection()
+    {
+        var profile = new SetupProfileDocument(
+            SetupProfileDocument.CurrentKind,
+            SetupProfileDocument.CurrentSchemaVersion,
+            DateTimeOffset.UtcNow,
+            "development",
+            []);
+
+        var exception = Assert.Throws<SetupProfileValidationException>(() => _serializer.Serialize(profile));
+
+        Assert.Contains(exception.Errors, error => error.Code == "profile.applications.empty");
+    }
+}

--- a/tests/AgenStart.Application.Tests/SetupProfileSerializerTests.cs
+++ b/tests/AgenStart.Application.Tests/SetupProfileSerializerTests.cs
@@ -67,7 +67,7 @@ public sealed class SetupProfileSerializerTests
           "profileId": "development",
           "applications": [
             { "applicationId": "git" },
-            { "applicationId": "Git" }
+            { "applicationId": "git" }
           ]
         }
         """;
@@ -76,6 +76,27 @@ public sealed class SetupProfileSerializerTests
 
         Assert.False(result.IsValid);
         Assert.Contains(result.Errors, error => error.Code == "profile.application_id.duplicate");
+    }
+
+    [Fact]
+    public void Deserialize_RejectsNonCanonicalUppercaseApplicationId()
+    {
+        const string json = """
+        {
+          "kind": "agenstart.setup",
+          "schemaVersion": 1,
+          "createdAtUtc": "2026-09-04T12:00:00+00:00",
+          "profileId": "development",
+          "applications": [
+            { "applicationId": "Git" }
+          ]
+        }
+        """;
+
+        var result = _serializer.Deserialize(json);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Code == "profile.application_id.invalid");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements the portable, versioned core format for #9 before wiring it into the desktop UI.

### Profile contract
- `agenstart.setup` schema version `1`
- canonical AgenStart application IDs only
- optional recommendation context
- optional profile metadata
- no provider command arguments and no machine inventory snapshot

### Validation / parser
- strict JSON parsing with unknown fields rejected
- 256 KB document safety limit
- supported-kind and schema-version checks
- portable ID validation
- duplicate application detection (case-insensitive)
- application-count and context-length limits
- malformed/corrupted profiles fail cleanly without reaching installation planning

### Privacy / portability
- no hostname, username, serial number, MAC address, personal file path or hardware fingerprint fields
- package-provider identities are resolved later from the destination machine's trusted catalogue
- destination installed-software state will be re-evaluated instead of being copied from the source PC

### Verification
- round-trip serialization test
- unsupported schema rejection
- duplicate ID rejection
- unknown field rejection
- malformed JSON rejection
- empty selection rejection
- JSON Schema + format documentation

This is the first implementation slice of #9. UI export/import and desired-vs-current preview follow in the next slice.

Related to #9.