### PR TITLE
feat: wire reproducible setup import and export

### DIFF
--- a/src/AgenStart.Desktop/LocalData/LocalExperienceViewModel.cs
+++ b/src/AgenStart.Desktop/LocalData/LocalExperienceViewModel.cs
@@ -54,7 +54,13 @@ public sealed class LocalExperienceViewModel : INotifyPropertyChanged
     public SetupHistoryRowViewModel? SelectedHistory
     {
         get => _selectedHistory;
-        set => SetField(ref _selectedHistory, value);
+        set
+        {
+            if (SetField(ref _selectedHistory, value))
+            {
+                OnPropertyChanged(nameof(CanExportSelectedHistory));
+            }
+        }
     }
 
     public bool AnalyzeOnStartup
@@ -84,6 +90,7 @@ public sealed class LocalExperienceViewModel : INotifyPropertyChanged
     }
 
     public bool HasHistory => HistoryEntries.Count > 0;
+    public bool CanExportSelectedHistory => SelectedHistory is not null;
     public bool TelemetryAvailable => false;
     public bool ExportManagementAvailable => false;
 

--- a/src/AgenStart.Desktop/Views/HistoryView.axaml
+++ b/src/AgenStart.Desktop/Views/HistoryView.axaml
@@ -73,8 +73,8 @@
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
               </ItemsControl>
-              <Button Classes="secondary" Content="Export setup" IsEnabled="{Binding ExportManagementAvailable}" Margin="0,10,0,0" />
-              <TextBlock Text="Reusable setup export arrives with milestone #9." Foreground="{StaticResource AgenMutedBrush}" FontSize="12" TextWrapping="Wrap" />
+              <Button Classes="secondary" Content="Export setup" IsEnabled="{Binding CanExportSelectedHistory}" Click="ExportSetupButton_OnClick" Margin="0,10,0,0" />
+              <TextBlock Text="Exports portable AgenStart application IDs only — no machine identifiers or personal data." Foreground="{StaticResource AgenMutedBrush}" FontSize="12" TextWrapping="Wrap" />
             </StackPanel>
           </Border>
         </StackPanel>

--- a/src/AgenStart.Desktop/Views/HistoryView.axaml.cs
+++ b/src/AgenStart.Desktop/Views/HistoryView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace AgenStart.Desktop.Views;
 
@@ -8,4 +9,9 @@ public sealed partial class HistoryView : UserControl
     {
         InitializeComponent();
     }
+
+    public event EventHandler? ExportSetupRequested;
+
+    private void ExportSetupButton_OnClick(object? sender, RoutedEventArgs e) =>
+        ExportSetupRequested?.Invoke(this, EventArgs.Empty);
 }

--- a/src/AgenStart.Desktop/Views/MainWindow.axaml.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.axaml.cs
@@ -1,23 +1,39 @@
 using System.ComponentModel;
+using System.Text;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using Avalonia.Platform.Storage;
 using AgenStart.Application.Installation;
+using AgenStart.Application.Profiles;
+using AgenStart.Catalogue;
 using AgenStart.Core.Catalogue;
 using AgenStart.Desktop.LocalData;
 using AgenStart.Desktop.ViewModels;
+using AgenStart.Recommendations;
 
 namespace AgenStart.Desktop.Views;
 
 public sealed partial class MainWindow : Window
 {
+    private static readonly FilePickerFileType SetupProfileFileType = new("AgenStart setup")
+    {
+        Patterns = ["*.agenstart.json", "*.json"]
+    };
+
     private readonly CancellationTokenSource _lifetimeCancellation = new();
     private readonly MainWindowViewModel _viewModel;
     private readonly LocalExperienceViewModel _localExperience = new();
+    private readonly SetupProfileSerializer _setupProfileSerializer = new();
+    private readonly SoftwareCatalogueLoader _catalogueLoader = new();
     private HistoryView? _historyView;
     private SettingsView? _settingsView;
     private Button? _historyButton;
     private Button? _settingsButton;
+    private Button? _importSetupButton;
+    private Button? _exportCurrentSetupButton;
+    private TextBlock? _importStatusText;
     private Guid? _currentHistoryEntryId;
 
     public MainWindow()
@@ -35,6 +51,7 @@ public sealed partial class MainWindow : Window
         ReportButton.IsEnabled = false;
 
         InstallUtilityViews();
+        InstallSetupProfileActions();
 
         _viewModel.PropertyChanged += ViewModel_OnPropertyChanged;
         Opened += OnOpened;
@@ -248,6 +265,7 @@ public sealed partial class MainWindow : Window
             DataContext = _localExperience,
             IsVisible = false
         };
+        _historyView.ExportSetupRequested += HistoryView_OnExportSetupRequested;
         _settingsView = new SettingsView
         {
             DataContext = _localExperience,
@@ -272,12 +290,46 @@ public sealed partial class MainWindow : Window
         }
     }
 
+    private void InstallSetupProfileActions()
+    {
+        _importSetupButton = FindButtonByContent("Import a setup");
+        if (_importSetupButton is not null)
+        {
+            _importSetupButton.IsEnabled = StorageProvider.CanOpen;
+            _importSetupButton.Click += ImportSetupButton_OnClick;
+
+            if (_importSetupButton.Parent?.Parent is StackPanel overviewColumn)
+            {
+                _importStatusText = new TextBlock
+                {
+                    IsVisible = false,
+                    FontSize = 13,
+                    Margin = new Thickness(0, 10, 0, 0)
+                };
+                _importStatusText.Classes.Add("subtitle");
+                overviewColumn.Children.Add(_importStatusText);
+            }
+        }
+
+        _exportCurrentSetupButton = FindButtonByContent("Export this setup");
+        if (_exportCurrentSetupButton is not null)
+        {
+            _exportCurrentSetupButton.IsEnabled = false;
+            _exportCurrentSetupButton.Click += ExportCurrentSetupButton_OnClick;
+        }
+    }
+
     private Button? FindNavigationButton(string label) =>
         this.GetLogicalDescendants()
             .OfType<Button>()
             .FirstOrDefault(button => button.GetLogicalDescendants()
                 .OfType<TextBlock>()
                 .Any(text => string.Equals(text.Text, label, StringComparison.Ordinal)));
+
+    private Button? FindButtonByContent(string content) =>
+        this.GetLogicalDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(button => string.Equals(button.Content as string, content, StringComparison.Ordinal));
 
     private void HistoryButton_OnClick(object? sender, RoutedEventArgs e)
     {
@@ -293,6 +345,292 @@ public sealed partial class MainWindow : Window
         {
             ShowUtilityPage(_settingsView, _settingsButton);
         }
+    }
+
+    private async void ImportSetupButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await ImportSetupAsync();
+        }
+        catch (OperationCanceledException) when (_lifetimeCancellation.IsCancellationRequested)
+        {
+        }
+        catch (IOException)
+        {
+            SetImportStatus("AgenStart could not read the selected setup file.");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            SetImportStatus("AgenStart does not have permission to read the selected setup file.");
+        }
+    }
+
+    private async Task ImportSetupAsync()
+    {
+        if (!StorageProvider.CanOpen)
+        {
+            SetImportStatus("File import is not available on this platform.");
+            return;
+        }
+
+        var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Import AgenStart setup",
+            AllowMultiple = false,
+            FileTypeFilter = [SetupProfileFileType]
+        });
+        var file = files.FirstOrDefault();
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenReadAsync();
+        if (stream.CanSeek && stream.Length > SetupProfileSerializer.MaxDocumentBytes)
+        {
+            SetImportStatus("This setup file is larger than AgenStart's 256 KB safety limit.");
+            return;
+        }
+
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: false);
+        var json = await reader.ReadToEndAsync(_lifetimeCancellation.Token);
+        var readResult = _setupProfileSerializer.Deserialize(json);
+        if (!readResult.IsValid || readResult.Profile is null)
+        {
+            SetImportStatus(readResult.Errors.FirstOrDefault()?.Message ?? "This setup file is invalid.");
+            return;
+        }
+
+        var profileDocument = readResult.Profile;
+        if (!TryParseProfileId(profileDocument.ProfileId, out var profile))
+        {
+            SetImportStatus($"Profile '{profileDocument.ProfileId}' is not supported by this AgenStart build.");
+            return;
+        }
+
+        var catalogue = LoadCatalogue();
+        var catalogueById = catalogue.Applications.ToDictionary(application => application.Id, StringComparer.OrdinalIgnoreCase);
+        var unknownApplication = profileDocument.Applications
+            .FirstOrDefault(application => !catalogueById.ContainsKey(application.ApplicationId));
+        if (unknownApplication is not null)
+        {
+            SetImportStatus($"'{unknownApplication.ApplicationId}' is not present in the current trusted AgenStart catalogue.");
+            return;
+        }
+
+        if (!_viewModel.HasSnapshot)
+        {
+            SetImportStatus("Checking this PC locally before comparing the imported setup…");
+            await _viewModel.AnalyzeAsync(_lifetimeCancellation.Token);
+            if (!_viewModel.HasSnapshot)
+            {
+                SetImportStatus("AgenStart could not analyse this PC, so the imported setup was not applied.");
+                return;
+            }
+
+            EnablePostAnalysisNavigation();
+        }
+
+        _viewModel.SelectProfile(profile);
+        SetImportStatus("Comparing the imported setup with this PC…");
+        await _viewModel.BuildRecommendationsAsync(_lifetimeCancellation.Token);
+        if (!_viewModel.HasRecommendations)
+        {
+            SetImportStatus("AgenStart could not compare the imported setup with the current catalogue and inventory.");
+            return;
+        }
+
+        var generatedRows = _viewModel.Recommendations.ToDictionary(row => row.ApplicationId, StringComparer.OrdinalIgnoreCase);
+        var desiredRows = new List<RecommendationRowViewModel>(profileDocument.Applications.Count);
+        foreach (var desiredApplication in profileDocument.Applications)
+        {
+            if (!generatedRows.TryGetValue(desiredApplication.ApplicationId, out var row))
+            {
+                SetImportStatus($"{catalogueById[desiredApplication.ApplicationId].Name} is not available for the imported {profileDocument.ProfileId} profile in this catalogue.");
+                return;
+            }
+
+            if (row.Disposition is not (RecommendationDisposition.Recommended or RecommendationDisposition.AlreadyInstalled))
+            {
+                SetImportStatus($"{row.Name} cannot be safely applied on this PC: {row.Status}.");
+                return;
+            }
+
+            if (row.Disposition == RecommendationDisposition.Recommended &&
+                catalogueById[row.ApplicationId].WindowsPackage is null)
+            {
+                SetImportStatus($"{row.Name} has no trusted Windows package mapping in the current catalogue.");
+                return;
+            }
+
+            desiredRows.Add(row);
+        }
+
+        var desiredIds = profileDocument.Applications
+            .Select(application => application.ApplicationId)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in _viewModel.Recommendations
+                     .Where(row => !desiredIds.Contains(row.ApplicationId))
+                     .ToArray())
+        {
+            _viewModel.Recommendations.Remove(row);
+        }
+
+        foreach (var row in desiredRows.Where(row => row.CanSelect))
+        {
+            if (row.IsSelected)
+            {
+                row.IsSelected = false;
+            }
+            row.IsSelected = true;
+        }
+
+        RecommendationsButton.IsEnabled = true;
+        if (_viewModel.SelectedCount == 0)
+        {
+            SetImportStatus($"Imported setup already satisfied: all {profileDocument.Applications.Count} application(s) are installed on this PC.");
+            return;
+        }
+
+        if (!_viewModel.PrepareReview())
+        {
+            SetImportStatus("The imported setup produced no installable changes after comparison.");
+            return;
+        }
+
+        SetImportStatus($"Imported {profileDocument.Applications.Count} application(s). Review the exact changes before installation.");
+        ReviewButton.IsEnabled = true;
+        ShowReview();
+    }
+
+    private async void ExportCurrentSetupButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (!_viewModel.HasReport || _viewModel.ReviewItems.Count == 0)
+        {
+            return;
+        }
+
+        var applications = _viewModel.ReviewItems.Select(row =>
+            new SetupProfileApplication(row.ApplicationId, row.Reason));
+        await SaveSetupProfileAsync(
+            ToProfileId(_viewModel.SelectedProfile),
+            applications,
+            $"{_viewModel.SelectedProfileName} setup");
+    }
+
+    private async void HistoryView_OnExportSetupRequested(object? sender, EventArgs e)
+    {
+        var selected = _localExperience.SelectedHistory?.Entry;
+        if (selected is null || !TryParseProfileId(selected.Profile, out var profile))
+        {
+            return;
+        }
+
+        var applications = selected.Applications
+            .Select(application => new SetupProfileApplication(application.ApplicationId))
+            .DistinctBy(application => application.ApplicationId, StringComparer.OrdinalIgnoreCase);
+        await SaveSetupProfileAsync(
+            ToProfileId(profile),
+            applications,
+            $"{selected.Profile} setup");
+    }
+
+    private async Task SaveSetupProfileAsync(
+        string profileId,
+        IEnumerable<SetupProfileApplication> applications,
+        string displayName)
+    {
+        if (!StorageProvider.CanSave)
+        {
+            return;
+        }
+
+        var portableApplications = applications
+            .Where(application => !string.IsNullOrWhiteSpace(application.ApplicationId))
+            .DistinctBy(application => application.ApplicationId, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (portableApplications.Length == 0)
+        {
+            return;
+        }
+
+        var document = new SetupProfileDocument(
+            SetupProfileDocument.CurrentKind,
+            SetupProfileDocument.CurrentSchemaVersion,
+            DateTimeOffset.UtcNow,
+            profileId,
+            portableApplications,
+            new SetupProfileMetadata(displayName, "0.1.0-alpha"));
+        var json = _setupProfileSerializer.Serialize(document);
+
+        var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Export AgenStart setup",
+            SuggestedFileName = $"AgenStart-{profileId}-{DateTime.Now:yyyyMMdd}.agenstart.json",
+            DefaultExtension = "json",
+            FileTypeChoices = [SetupProfileFileType],
+            ShowOverwritePrompt = true
+        });
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenWriteAsync();
+        if (stream.CanSeek)
+        {
+            stream.SetLength(0);
+        }
+
+        await using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        await writer.WriteAsync(json.AsMemory(), _lifetimeCancellation.Token);
+        await writer.FlushAsync(_lifetimeCancellation.Token);
+    }
+
+    private SoftwareCatalogue LoadCatalogue()
+    {
+        var cataloguePath = Path.Combine(AppContext.BaseDirectory, "Data", "catalogue.json");
+        using var catalogueStream = File.OpenRead(cataloguePath);
+        return _catalogueLoader.Load(catalogueStream);
+    }
+
+    private static bool TryParseProfileId(string? profileId, out UserProfile profile)
+    {
+        switch (profileId?.Trim().ToLowerInvariant())
+        {
+            case "personal":
+                profile = UserProfile.Personal;
+                return true;
+            case "development":
+                profile = UserProfile.Development;
+                return true;
+            case "business":
+                profile = UserProfile.Business;
+                return true;
+            case "creation":
+                profile = UserProfile.Creation;
+                return true;
+            case "training":
+                profile = UserProfile.Training;
+                return true;
+            default:
+                profile = default;
+                return false;
+        }
+    }
+
+    private static string ToProfileId(UserProfile profile) => profile.ToString().ToLowerInvariant();
+
+    private void SetImportStatus(string message)
+    {
+        if (_importStatusText is null)
+        {
+            return;
+        }
+
+        _importStatusText.Text = message;
+        _importStatusText.IsVisible = true;
     }
 
     private void ShowOverview() => ShowPage(OverviewPanel, OverviewButton, OverviewStripe);
@@ -418,6 +756,10 @@ public sealed partial class MainWindow : Window
         if (e.PropertyName == nameof(MainWindowViewModel.HasReport))
         {
             ReportButton.IsEnabled = _viewModel.HasReport;
+            if (_exportCurrentSetupButton is not null)
+            {
+                _exportCurrentSetupButton.IsEnabled = _viewModel.HasReport && StorageProvider.CanSave;
+            }
         }
     }
 
@@ -440,6 +782,10 @@ public sealed partial class MainWindow : Window
     private void OnClosed(object? sender, EventArgs e)
     {
         _viewModel.PropertyChanged -= ViewModel_OnPropertyChanged;
+        if (_historyView is not null)
+        {
+            _historyView.ExportSetupRequested -= HistoryView_OnExportSetupRequested;
+        }
         if (_historyButton is not null)
         {
             _historyButton.Click -= HistoryButton_OnClick;
@@ -447,6 +793,14 @@ public sealed partial class MainWindow : Window
         if (_settingsButton is not null)
         {
             _settingsButton.Click -= SettingsButton_OnClick;
+        }
+        if (_importSetupButton is not null)
+        {
+            _importSetupButton.Click -= ImportSetupButton_OnClick;
+        }
+        if (_exportCurrentSetupButton is not null)
+        {
+            _exportCurrentSetupButton.Click -= ExportCurrentSetupButton_OnClick;
         }
         Opened -= OnOpened;
         _lifetimeCancellation.Cancel();


### PR DESCRIPTION
## Summary

Completes the desktop-facing slice of #9 on top of the versioned setup-profile core.

### Import
- enables `Import a setup` from Overview
- opens only user-selected setup JSON through Avalonia's StorageProvider
- enforces the strict v1 parser and 256 KB safety limit
- rejects unsupported profile IDs and unknown catalogue application IDs
- runs/uses the local machine analysis before applying an imported setup
- reuses the existing recommendation engine to compare each desired app with the destination PC
- rejects incompatible, inventory-unknown, conflicted or unavailable imported items instead of guessing
- resolves exact Windows package mappings from the destination machine's trusted catalogue
- filters the comparison down to the imported desired set and routes installable changes through the existing Review screen
- if every desired app is already installed, reports the setup as already satisfied and schedules nothing

### Export
- enables `Export this setup` after a completed report
- exports the exact reviewed desired set, including already-installed members of that setup
- enables export from a selected local History session
- writes `agenstart.setup` schema v1 using the strict serializer
- exports canonical AgenStart application IDs and recommendation context only; no machine identifiers

### Security boundaries
- imported files never contain WinGet commands or arbitrary provider arguments
- package/source identities are re-resolved from the destination catalogue
- no installation occurs without Review + explicit agreement approval
- unknown/incompatible state fails closed
- no hostname, username, serial, MAC, personal file path or hardware fingerprint is exported

Related to #9.