### PR TITLE
docs: index engineering release guidance

### DIFF
--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -1,0 +1,5 @@
+# Engineering
+
+AgenStart engineering references:
+
+- [Release baseline and versioning](RELEASING.md) — AppFactory reusable release workflow, SemVer, CI gates, token behavior and reproducible Windows artifacts.


### PR DESCRIPTION
Adds a small engineering documentation index pointing to the new release baseline. This also gives the newly registered `main` release workflow its first normal post-registration push so we can validate the AppFactory consumer flow end to end.

Relates to #10.