### PR TITLE
feat: polish the first-run desktop UX after Windows smoke test

### DIFF
--- a/src/AgenStart.Desktop/Styles/AgenStartTheme.axaml
+++ b/src/AgenStart.Desktop/Styles/AgenStartTheme.axaml
@@ -8,6 +8,15 @@
     <Color x:Key="AgenTealColor">#176D64</Color>
     <Color x:Key="AgenAccentColor">#45CFC1</Color>
     <Color x:Key="AgenDividerColor">#D9DEDC</Color>
+    <Color x:Key="AgenSuccessColor">#2F7D5B</Color>
+    <Color x:Key="AgenWarningColor">#9A6700</Color>
+    <Color x:Key="AgenDangerColor">#A84E3E</Color>
+    <Color x:Key="AgenSoftTealColor">#E7F1EE</Color>
+    <Color x:Key="AgenSoftSuccessColor">#E7F3EC</Color>
+    <Color x:Key="AgenSoftWarningColor">#F7EEDB</Color>
+    <Color x:Key="AgenSoftDangerColor">#F8E8E4</Color>
+    <Color x:Key="AgenNavHoverColor">#12313C</Color>
+    <Color x:Key="AgenNavActiveColor">#17414A</Color>
 
     <SolidColorBrush x:Key="AgenNavBrush" Color="{StaticResource AgenNavColor}" />
     <SolidColorBrush x:Key="AgenSurfaceBrush" Color="{StaticResource AgenSurfaceColor}" />
@@ -16,6 +25,15 @@
     <SolidColorBrush x:Key="AgenTealBrush" Color="{StaticResource AgenTealColor}" />
     <SolidColorBrush x:Key="AgenAccentBrush" Color="{StaticResource AgenAccentColor}" />
     <SolidColorBrush x:Key="AgenDividerBrush" Color="{StaticResource AgenDividerColor}" />
+    <SolidColorBrush x:Key="AgenSuccessBrush" Color="{StaticResource AgenSuccessColor}" />
+    <SolidColorBrush x:Key="AgenWarningBrush" Color="{StaticResource AgenWarningColor}" />
+    <SolidColorBrush x:Key="AgenDangerBrush" Color="{StaticResource AgenDangerColor}" />
+    <SolidColorBrush x:Key="AgenSoftTealBrush" Color="{StaticResource AgenSoftTealColor}" />
+    <SolidColorBrush x:Key="AgenSoftSuccessBrush" Color="{StaticResource AgenSoftSuccessColor}" />
+    <SolidColorBrush x:Key="AgenSoftWarningBrush" Color="{StaticResource AgenSoftWarningColor}" />
+    <SolidColorBrush x:Key="AgenSoftDangerBrush" Color="{StaticResource AgenSoftDangerColor}" />
+    <SolidColorBrush x:Key="AgenNavHoverBrush" Color="{StaticResource AgenNavHoverColor}" />
+    <SolidColorBrush x:Key="AgenNavActiveBrush" Color="{StaticResource AgenNavActiveColor}" />
   </Styles.Resources>
 
   <Style Selector="Window">
@@ -36,16 +54,40 @@
     <Setter Property="FontSize" Value="16" />
   </Style>
 
+  <Style Selector="Button.nav:pointerover">
+    <Setter Property="Background" Value="{StaticResource AgenNavHoverBrush}" />
+    <Setter Property="Foreground" Value="#F6FBFC" />
+  </Style>
+
   <Style Selector="Button.nav:pointerover /template/ ContentPresenter">
-    <Setter Property="Background" Value="#15333E" />
+    <Setter Property="Background" Value="{StaticResource AgenNavHoverBrush}" />
+    <Setter Property="Foreground" Value="#F6FBFC" />
+  </Style>
+
+  <Style Selector="Button.nav.active">
+    <Setter Property="Background" Value="{StaticResource AgenNavActiveBrush}" />
+    <Setter Property="Foreground" Value="White" />
   </Style>
 
   <Style Selector="Button.nav.active /template/ ContentPresenter">
-    <Setter Property="Background" Value="#173B45" />
+    <Setter Property="Background" Value="{StaticResource AgenNavActiveBrush}" />
+    <Setter Property="Foreground" Value="White" />
   </Style>
 
   <Style Selector="Button.nav:disabled">
-    <Setter Property="Opacity" Value="0.38" />
+    <Setter Property="Opacity" Value="0.42" />
+    <Setter Property="Foreground" Value="#9AABB1" />
+    <Setter Property="Background" Value="Transparent" />
+  </Style>
+
+  <Style Selector="Button.nav:disabled:pointerover">
+    <Setter Property="Foreground" Value="#9AABB1" />
+    <Setter Property="Background" Value="Transparent" />
+  </Style>
+
+  <Style Selector="Button.nav:disabled:pointerover /template/ ContentPresenter">
+    <Setter Property="Foreground" Value="#9AABB1" />
+    <Setter Property="Background" Value="Transparent" />
   </Style>
 
   <Style Selector="Button.primary">
@@ -62,6 +104,7 @@
 
   <Style Selector="Button.primary:pointerover /template/ ContentPresenter">
     <Setter Property="Background" Value="#145E57" />
+    <Setter Property="Foreground" Value="White" />
   </Style>
 
   <Style Selector="Button.secondary">
@@ -74,6 +117,39 @@
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="CornerRadius" Value="8" />
     <Setter Property="FontSize" Value="16" />
+  </Style>
+
+  <Style Selector="Button.secondary:pointerover">
+    <Setter Property="Background" Value="#EEF2F0" />
+    <Setter Property="Foreground" Value="{StaticResource AgenTextBrush}" />
+  </Style>
+
+  <Style Selector="Button.secondary:pointerover /template/ ContentPresenter">
+    <Setter Property="Background" Value="#EEF2F0" />
+    <Setter Property="Foreground" Value="{StaticResource AgenTextBrush}" />
+  </Style>
+
+  <Style Selector="RadioButton.profileCard">
+    <Setter Property="Padding" Value="16,12" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{StaticResource AgenTextBrush}" />
+    <Setter Property="BorderBrush" Value="{StaticResource AgenDividerBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="8" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+  </Style>
+
+  <Style Selector="RadioButton.profileCard:pointerover">
+    <Setter Property="Background" Value="#EEF3F1" />
+    <Setter Property="Foreground" Value="{StaticResource AgenTextBrush}" />
+    <Setter Property="BorderBrush" Value="#9EBAB4" />
+  </Style>
+
+  <Style Selector="RadioButton.profileCard:checked">
+    <Setter Property="Background" Value="{StaticResource AgenSoftTealBrush}" />
+    <Setter Property="Foreground" Value="{StaticResource AgenTextBrush}" />
+    <Setter Property="BorderBrush" Value="{StaticResource AgenTealBrush}" />
+    <Setter Property="BorderThickness" Value="1.5" />
   </Style>
 
   <Style Selector="TextBlock.eyebrow">
@@ -99,5 +175,18 @@
     <Setter Property="BorderBrush" Value="{StaticResource AgenDividerBrush}" />
     <Setter Property="BorderThickness" Value="0,0,0,1" />
     <Setter Property="Padding" Value="8,13" />
+    <Setter Property="ClipToBounds" Value="True" />
+  </Style>
+
+  <Style Selector="Border.dataRow TextBlock">
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+  </Style>
+
+  <Style Selector="Border.statusBadge">
+    <Setter Property="CornerRadius" Value="14" />
+    <Setter Property="Padding" Value="10,5" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
   </Style>
 </Styles>

--- a/src/AgenStart.Desktop/ViewModels/RecommendationRowViewModel.cs
+++ b/src/AgenStart.Desktop/ViewModels/RecommendationRowViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Avalonia.Media;
 using AgenStart.Core.Catalogue;
 using AgenStart.Recommendations;
 
@@ -7,6 +8,17 @@ namespace AgenStart.Desktop.ViewModels;
 
 public sealed class RecommendationRowViewModel : INotifyPropertyChanged
 {
+    private static readonly IBrush TealBrush = new SolidColorBrush(Color.Parse("#176D64"));
+    private static readonly IBrush SuccessBrush = new SolidColorBrush(Color.Parse("#2F7D5B"));
+    private static readonly IBrush WarningBrush = new SolidColorBrush(Color.Parse("#9A6700"));
+    private static readonly IBrush DangerBrush = new SolidColorBrush(Color.Parse("#A84E3E"));
+    private static readonly IBrush MutedBrush = new SolidColorBrush(Color.Parse("#69747A"));
+    private static readonly IBrush SoftTealBrush = new SolidColorBrush(Color.Parse("#E7F1EE"));
+    private static readonly IBrush SoftSuccessBrush = new SolidColorBrush(Color.Parse("#E7F3EC"));
+    private static readonly IBrush SoftWarningBrush = new SolidColorBrush(Color.Parse("#F7EEDB"));
+    private static readonly IBrush SoftDangerBrush = new SolidColorBrush(Color.Parse("#F8E8E4"));
+    private static readonly IBrush SoftNeutralBrush = new SolidColorBrush(Color.Parse("#ECEFEE"));
+
     private bool _isSelected;
 
     public RecommendationRowViewModel(
@@ -22,6 +34,8 @@ public sealed class RecommendationRowViewModel : INotifyPropertyChanged
         CanSelect = decision.Disposition == RecommendationDisposition.Recommended;
         _isSelected = CanSelect && decision.SelectedByDefault;
         Status = BuildStatus(decision);
+        StatusIcon = BuildStatusIcon(decision);
+        (StatusBrush, StatusBackgroundBrush) = BuildStatusBrushes(decision);
         Initials = BuildInitials(decision.ApplicationName);
     }
 
@@ -36,6 +50,9 @@ public sealed class RecommendationRowViewModel : INotifyPropertyChanged
     public RecommendationDisposition Disposition { get; }
     public bool CanSelect { get; }
     public string Status { get; }
+    public string StatusIcon { get; }
+    public IBrush StatusBrush { get; }
+    public IBrush StatusBackgroundBrush { get; }
 
     public bool IsSelected
     {
@@ -68,6 +85,52 @@ public sealed class RecommendationRowViewModel : INotifyPropertyChanged
             _ => "Recommended"
         }
     };
+
+    private static string BuildStatusIcon(RecommendationDecision decision) => decision.Disposition switch
+    {
+        RecommendationDisposition.AlreadyInstalled => "✓",
+        RecommendationDisposition.Incompatible => "!",
+        RecommendationDisposition.CompatibilityUnknown => "?",
+        RecommendationDisposition.InventoryUnknown => "?",
+        RecommendationDisposition.Conflict => "!",
+        RecommendationDisposition.Unavailable => "!",
+        _ => decision.Level switch
+        {
+            RecommendationLevel.Essential => "◆",
+            RecommendationLevel.Recommended => "✦",
+            RecommendationLevel.Optional => "○",
+            _ => "✦"
+        }
+    };
+
+    private static (IBrush Foreground, IBrush Background) BuildStatusBrushes(RecommendationDecision decision)
+    {
+        if (decision.Disposition == RecommendationDisposition.AlreadyInstalled)
+        {
+            return (SuccessBrush, SoftSuccessBrush);
+        }
+
+        if (decision.Disposition == RecommendationDisposition.Incompatible)
+        {
+            return (DangerBrush, SoftDangerBrush);
+        }
+
+        if (decision.Disposition is RecommendationDisposition.CompatibilityUnknown
+            or RecommendationDisposition.InventoryUnknown
+            or RecommendationDisposition.Conflict
+            or RecommendationDisposition.Unavailable)
+        {
+            return (WarningBrush, SoftWarningBrush);
+        }
+
+        return decision.Level switch
+        {
+            RecommendationLevel.Essential => (TealBrush, SoftTealBrush),
+            RecommendationLevel.Recommended => (TealBrush, SoftTealBrush),
+            RecommendationLevel.Optional => (MutedBrush, SoftNeutralBrush),
+            _ => (TealBrush, SoftTealBrush)
+        };
+    }
 
     private static string BuildInitials(string name)
     {

--- a/src/AgenStart.Desktop/Views/MainWindow.UiPolish.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.UiPolish.cs
@@ -17,10 +17,13 @@ public sealed partial class MainWindow
     private static readonly IBrush GuidanceBackgroundBrush = new SolidColorBrush(Color.Parse("#EEF3F1"));
     private static readonly IBrush GuidanceMutedBrush = new SolidColorBrush(Color.Parse("#69747A"));
     private static readonly IBrush GuidanceTextBrush = new SolidColorBrush(Color.Parse("#10242B"));
+    private static readonly IBrush SuccessBrush = new SolidColorBrush(Color.Parse("#2F7D5B"));
+    private static readonly IBrush TealBrush = new SolidColorBrush(Color.Parse("#176D64"));
 
     private bool _uiPolishApplied;
     private TextBlock? _profileGuidanceText;
     private TextBlock? _profileSummaryIcon;
+    private Border? _recommendationLoadingCard;
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
@@ -35,16 +38,19 @@ public sealed partial class MainWindow
         PolishMachineRows();
         PolishUsageProfiles();
         AddProfileGuidance();
+        AddRecommendationLoadingCard();
         RecommendationsPanel.LayoutUpdated += (_, _) => ApplyRecommendationStatusVisuals();
         _viewModel.PropertyChanged += (_, args) =>
         {
             if (args.PropertyName is nameof(MainWindowViewModel.HasRecommendations)
-                or nameof(MainWindowViewModel.SelectedProfile))
+                or nameof(MainWindowViewModel.SelectedProfile)
+                or nameof(MainWindowViewModel.IsBusy))
             {
                 Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                 {
                     RefreshProfileCardStates();
                     RefreshProfileGuidance();
+                    RefreshRecommendationLoadingCard();
                     ApplyRecommendationStatusVisuals();
                 });
             }
@@ -208,6 +214,92 @@ public sealed partial class MainWindow
                 UserProfile.Training => "◎",
                 _ => "○"
             };
+        }
+    }
+
+    private void AddRecommendationLoadingCard()
+    {
+        var progressBar = UsageProfilePanel.GetVisualDescendants().OfType<ProgressBar>().FirstOrDefault();
+        if (progressBar?.Parent is not StackPanel leftColumn || _recommendationLoadingCard is not null)
+        {
+            return;
+        }
+
+        progressBar.IsVisible = false;
+
+        var steps = new StackPanel { Spacing = 8 };
+        steps.Children.Add(BuildLoadingStep("✓", "Machine capabilities already analysed", SuccessBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Read installed applications", TealBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Load the trusted software catalogue", TealBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Match apps to the selected usage profile", TealBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Apply compatibility and installed-state rules", TealBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Finalize the recommendation list", TealBrush));
+
+        var content = new StackPanel { Spacing = 10 };
+        content.Children.Add(new TextBlock
+        {
+            Text = "Building your recommendations",
+            FontSize = 16,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = GuidanceTextBrush
+        });
+        content.Children.Add(new TextBlock
+        {
+            Text = "AgenStart is checking these inputs before showing your final list. No fake percentage is used.",
+            FontSize = 13,
+            Foreground = GuidanceMutedBrush,
+            TextWrapping = TextWrapping.Wrap
+        });
+        content.Children.Add(new ProgressBar
+        {
+            IsIndeterminate = true,
+            Height = 3,
+            Margin = new Avalonia.Thickness(0, 2, 0, 4)
+        });
+        content.Children.Add(steps);
+
+        _recommendationLoadingCard = new Border
+        {
+            Background = GuidanceBackgroundBrush,
+            BorderBrush = ProfileDefaultBorderBrush,
+            BorderThickness = new Avalonia.Thickness(1),
+            CornerRadius = new Avalonia.CornerRadius(8),
+            Padding = new Avalonia.Thickness(16, 14),
+            Margin = new Avalonia.Thickness(0, 16, 0, 0),
+            IsVisible = false,
+            Child = content
+        };
+
+        leftColumn.Children.Add(_recommendationLoadingCard);
+        RefreshRecommendationLoadingCard();
+    }
+
+    private static Control BuildLoadingStep(string icon, string text, IBrush brush)
+    {
+        var row = new StackPanel { Orientation = Avalonia.Layout.Orientation.Horizontal, Spacing = 9 };
+        row.Children.Add(new TextBlock
+        {
+            Text = icon,
+            Width = 18,
+            TextAlignment = Avalonia.Media.TextAlignment.Center,
+            Foreground = brush,
+            FontWeight = FontWeight.SemiBold
+        });
+        row.Children.Add(new TextBlock
+        {
+            Text = text,
+            Foreground = GuidanceMutedBrush,
+            FontSize = 13,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+        });
+        return row;
+    }
+
+    private void RefreshRecommendationLoadingCard()
+    {
+        if (_recommendationLoadingCard is not null)
+        {
+            _recommendationLoadingCard.IsVisible = UsageProfilePanel.IsVisible && _viewModel.IsBusy;
         }
     }
 

--- a/src/AgenStart.Desktop/Views/MainWindow.UiPolish.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.UiPolish.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Media;

--- a/src/AgenStart.Desktop/Views/MainWindow.UiPolish.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.UiPolish.cs
@@ -1,0 +1,239 @@
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using AgenStart.Core.Catalogue;
+using AgenStart.Desktop.ViewModels;
+
+namespace AgenStart.Desktop.Views;
+
+public sealed partial class MainWindow
+{
+    private static readonly IBrush ProfileHoverBrush = new SolidColorBrush(Color.Parse("#EEF3F1"));
+    private static readonly IBrush ProfileSelectedBrush = new SolidColorBrush(Color.Parse("#E7F1EE"));
+    private static readonly IBrush ProfileDefaultBorderBrush = new SolidColorBrush(Color.Parse("#D9DEDC"));
+    private static readonly IBrush ProfileHoverBorderBrush = new SolidColorBrush(Color.Parse("#9EBAB4"));
+    private static readonly IBrush ProfileSelectedBorderBrush = new SolidColorBrush(Color.Parse("#176D64"));
+    private static readonly IBrush GuidanceBackgroundBrush = new SolidColorBrush(Color.Parse("#EEF3F1"));
+    private static readonly IBrush GuidanceMutedBrush = new SolidColorBrush(Color.Parse("#69747A"));
+    private static readonly IBrush GuidanceTextBrush = new SolidColorBrush(Color.Parse("#10242B"));
+
+    private bool _uiPolishApplied;
+    private TextBlock? _profileGuidanceText;
+    private TextBlock? _profileSummaryIcon;
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        if (_uiPolishApplied)
+        {
+            return;
+        }
+
+        _uiPolishApplied = true;
+        PolishMachineRows();
+        PolishUsageProfiles();
+        AddProfileGuidance();
+        RecommendationsPanel.LayoutUpdated += (_, _) => ApplyRecommendationStatusVisuals();
+        _viewModel.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName is nameof(MainWindowViewModel.HasRecommendations)
+                or nameof(MainWindowViewModel.SelectedProfile))
+            {
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    RefreshProfileCardStates();
+                    RefreshProfileGuidance();
+                    ApplyRecommendationStatusVisuals();
+                });
+            }
+        };
+    }
+
+    private void PolishMachineRows()
+    {
+        foreach (var row in YourPcPanel
+                     .GetVisualDescendants()
+                     .OfType<Border>()
+                     .Where(border => border.Classes.Contains("dataRow")))
+        {
+            row.ClipToBounds = true;
+            if (row.Child is not Grid grid || grid.ColumnDefinitions.Count < 3)
+            {
+                continue;
+            }
+
+            grid.ColumnSpacing = 14;
+            grid.ColumnDefinitions[2].Width = new GridLength(132);
+
+            foreach (var textBlock in grid.Children.OfType<TextBlock>())
+            {
+                textBlock.TextTrimming = TextTrimming.CharacterEllipsis;
+                textBlock.VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center;
+            }
+        }
+    }
+
+    private void PolishUsageProfiles()
+    {
+        foreach (var radio in UsageProfilePanel.GetLogicalDescendants().OfType<RadioButton>())
+        {
+            if (radio.Parent is not Border card)
+            {
+                continue;
+            }
+
+            card.BorderThickness = new Avalonia.Thickness(1);
+            card.CornerRadius = new Avalonia.CornerRadius(8);
+
+            card.PointerEntered += (_, _) =>
+            {
+                if (radio.IsChecked != true)
+                {
+                    card.Background = ProfileHoverBrush;
+                    card.BorderBrush = ProfileHoverBorderBrush;
+                }
+            };
+
+            card.PointerExited += (_, _) => RefreshProfileCardState(radio, card);
+            radio.Click += (_, _) => Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                RefreshProfileCardStates();
+                RefreshProfileGuidance();
+            });
+        }
+
+        _profileSummaryIcon = UsageProfilePanel
+            .GetVisualDescendants()
+            .OfType<TextBlock>()
+            .FirstOrDefault(text => string.Equals(text.Text, "</>", StringComparison.Ordinal));
+
+        RefreshProfileCardStates();
+        RefreshProfileGuidance();
+    }
+
+    private void RefreshProfileCardStates()
+    {
+        foreach (var radio in UsageProfilePanel.GetLogicalDescendants().OfType<RadioButton>())
+        {
+            if (radio.Parent is Border card)
+            {
+                RefreshProfileCardState(radio, card);
+            }
+        }
+    }
+
+    private static void RefreshProfileCardState(RadioButton radio, Border card)
+    {
+        if (radio.IsChecked == true)
+        {
+            card.Background = ProfileSelectedBrush;
+            card.BorderBrush = ProfileSelectedBorderBrush;
+            card.BorderThickness = new Avalonia.Thickness(1.5);
+        }
+        else
+        {
+            card.Background = Brushes.Transparent;
+            card.BorderBrush = ProfileDefaultBorderBrush;
+            card.BorderThickness = new Avalonia.Thickness(1);
+        }
+    }
+
+    private void AddProfileGuidance()
+    {
+        var selectedLabel = UsageProfilePanel
+            .GetVisualDescendants()
+            .OfType<TextBlock>()
+            .FirstOrDefault(text => string.Equals(text.Text, "Selected:", StringComparison.Ordinal));
+
+        if (selectedLabel?.Parent is not StackPanel summary || _profileGuidanceText is not null)
+        {
+            return;
+        }
+
+        var content = new StackPanel { Spacing = 6 };
+        content.Children.Add(new TextBlock
+        {
+            Text = "AgenStart will prioritize",
+            FontSize = 13,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = GuidanceTextBrush
+        });
+
+        _profileGuidanceText = new TextBlock
+        {
+            FontSize = 13,
+            Foreground = GuidanceMutedBrush,
+            TextWrapping = TextWrapping.Wrap,
+            LineHeight = 20
+        };
+        content.Children.Add(_profileGuidanceText);
+
+        summary.Children.Add(new Border
+        {
+            Background = GuidanceBackgroundBrush,
+            CornerRadius = new Avalonia.CornerRadius(8),
+            Padding = new Avalonia.Thickness(14, 12),
+            Margin = new Avalonia.Thickness(0, 12, 0, 0),
+            Child = content
+        });
+
+        RefreshProfileGuidance();
+    }
+
+    private void RefreshProfileGuidance()
+    {
+        if (_profileGuidanceText is not null)
+        {
+            _profileGuidanceText.Text = _viewModel.SelectedProfile switch
+            {
+                UserProfile.Personal => "Browsers · communication · media · everyday utilities",
+                UserProfile.Development => "Editors & IDEs · terminals · Git · databases · developer utilities",
+                UserProfile.Business => "Office · communication · productivity · collaboration",
+                UserProfile.Creation => "Design · media · content · creative utilities",
+                UserProfile.Training => "Learning tools · browsers · document utilities · guided study",
+                _ => "Tools that fit the way you use this PC"
+            };
+        }
+
+        if (_profileSummaryIcon is not null)
+        {
+            _profileSummaryIcon.Text = _viewModel.SelectedProfile switch
+            {
+                UserProfile.Personal => "⌂",
+                UserProfile.Development => "</>",
+                UserProfile.Business => "▦",
+                UserProfile.Creation => "✦",
+                UserProfile.Training => "◎",
+                _ => "○"
+            };
+        }
+    }
+
+    private void ApplyRecommendationStatusVisuals()
+    {
+        if (!RecommendationsPanel.IsVisible)
+        {
+            return;
+        }
+
+        foreach (var textBlock in RecommendationsPanel.GetVisualDescendants().OfType<TextBlock>())
+        {
+            if (textBlock.DataContext is not RecommendationRowViewModel row)
+            {
+                continue;
+            }
+
+            if (!string.Equals(textBlock.Text, row.Status, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            textBlock.Text = $"{row.StatusIcon}  {row.Status}";
+            textBlock.Foreground = row.StatusBrush;
+            textBlock.FontWeight = FontWeight.SemiBold;
+            textBlock.FontSize = 13;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Apply the first UI polish pass from the real Windows v0.1.0 smoke test.

### Included
- fix sidebar hover/active/disabled contrast so dark navigation never turns text/icons black
- add shared semantic success/warning/danger/soft-state colors
- clip and trim machine-detail rows to prevent CPU/GPU labels colliding with status columns
- make usage-profile cards reflect the actual selected radio option instead of leaving Development visually highlighted
- add contextual profile guidance and profile-specific priorities
- add semantic recommendation status icon + color treatment for recommended/essential/optional/already-installed/incompatible/unknown states
- replace the unexplained profile loading strip with an explanatory recommendation-building card that lists what AgenStart is checking (still no fake percentage)

### Follow-up
Issue #53 remains open for a deeper pipeline change that exposes *real per-stage completion/current/pending events* from the recommendation engine. This PR removes the opaque loading state but deliberately does not fake stage completion.

Closes #50
Closes #51
Closes #52
Closes #55

Part of #53