### PR TITLE
feat: show real recommendation pipeline progress

### DIFF
--- a/src/AgenStart.Core/Recommendations/RecommendationPipelineDiagnostics.cs
+++ b/src/AgenStart.Core/Recommendations/RecommendationPipelineDiagnostics.cs
@@ -1,0 +1,73 @@
+namespace AgenStart.Core.Recommendations;
+
+public enum RecommendationPipelineStage
+{
+    LoadingTrustedCatalogue,
+    ReadingInstalledApplications,
+    ApplyingInstalledStateRules,
+    MatchingSelectedProfile,
+    FinalizingRecommendations
+}
+
+public static class RecommendationPipelineDiagnostics
+{
+    private static readonly object Sync = new();
+    private static Action<RecommendationPipelineStage>? _stageChanged;
+
+    public static IDisposable Subscribe(Action<RecommendationPipelineStage> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        lock (Sync)
+        {
+            _stageChanged += handler;
+        }
+
+        return new Subscription(handler);
+    }
+
+    public static void Report(RecommendationPipelineStage stage)
+    {
+        Action<RecommendationPipelineStage>? handlers;
+        lock (Sync)
+        {
+            handlers = _stageChanged;
+        }
+
+        if (handlers is null)
+        {
+            return;
+        }
+
+        foreach (Action<RecommendationPipelineStage> handler in handlers.GetInvocationList())
+        {
+            try
+            {
+                handler(stage);
+            }
+            catch
+            {
+                // UI diagnostics must never be able to break recommendation generation.
+            }
+        }
+    }
+
+    private sealed class Subscription(Action<RecommendationPipelineStage> handler) : IDisposable
+    {
+        private Action<RecommendationPipelineStage>? _handler = handler;
+
+        public void Dispose()
+        {
+            var handlerToRemove = Interlocked.Exchange(ref _handler, null);
+            if (handlerToRemove is null)
+            {
+                return;
+            }
+
+            lock (Sync)
+            {
+                _stageChanged -= handlerToRemove;
+            }
+        }
+    }
+}

--- a/src/AgenStart.Core/Recommendations/RecommendationPipelineDiagnostics.cs
+++ b/src/AgenStart.Core/Recommendations/RecommendationPipelineDiagnostics.cs
@@ -4,8 +4,7 @@ public enum RecommendationPipelineStage
 {
     LoadingTrustedCatalogue,
     ReadingInstalledApplications,
-    ApplyingInstalledStateRules,
-    MatchingSelectedProfile,
+    EvaluatingRecommendationRules,
     FinalizingRecommendations
 }
 
@@ -47,7 +46,7 @@ public static class RecommendationPipelineDiagnostics
             }
             catch
             {
-                // UI diagnostics must never be able to break recommendation generation.
+                // Diagnostics must never be able to break recommendation generation.
             }
         }
     }

--- a/src/AgenStart.Desktop/Views/MainWindow.RecommendationProgress.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.RecommendationProgress.cs
@@ -1,0 +1,284 @@
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.Threading;
+using AgenStart.Core.Recommendations;
+using AgenStart.Desktop.ViewModels;
+
+namespace AgenStart.Desktop.Views;
+
+public sealed partial class MainWindow
+{
+    private static readonly IBrush RecommendationProgressDangerBrush =
+        new SolidColorBrush(Color.Parse("#A84E3E"));
+
+    private readonly List<RecommendationProgressVisual> _recommendationProgressSteps = [];
+    private IDisposable? _recommendationProgressSubscription;
+    private TextBlock? _recommendationProgressTitle;
+    private RecommendationPipelineStage? _activeRecommendationStage;
+    private bool _recommendationProgressTrackingInstalled;
+    private bool _recommendationProgressFailed;
+
+    private void InstallRecommendationProgressTracking()
+    {
+        if (_recommendationProgressTrackingInstalled || _recommendationLoadingCard is null)
+        {
+            return;
+        }
+
+        _recommendationProgressTrackingInstalled = true;
+        CaptureRecommendationProgressVisuals();
+        _recommendationProgressSubscription = RecommendationPipelineDiagnostics.Subscribe(stage =>
+            Dispatcher.UIThread.Post(() => OnRecommendationPipelineStageChanged(stage)));
+
+        _viewModel.PropertyChanged += RecommendationProgressViewModel_OnPropertyChanged;
+        Recommendations.CollectionChanged += (_, args) =>
+        {
+            if (_viewModel.IsBusy && UsageProfilePanel.IsVisible && args.NewItems is { Count: > 0 })
+            {
+                SetRecommendationProgressStage(RecommendationPipelineStage.FinalizingRecommendations);
+            }
+        };
+
+        Closed += (_, _) =>
+        {
+            _recommendationProgressSubscription?.Dispose();
+            _recommendationProgressSubscription = null;
+        };
+
+        ResetRecommendationProgress();
+    }
+
+    private void CaptureRecommendationProgressVisuals()
+    {
+        if (_recommendationLoadingCard is null)
+        {
+            return;
+        }
+
+        _recommendationProgressTitle = _recommendationLoadingCard
+            .GetLogicalDescendants()
+            .OfType<TextBlock>()
+            .FirstOrDefault(text => string.Equals(
+                text.Text,
+                "Building your recommendations",
+                StringComparison.Ordinal));
+
+        string[] labels =
+        [
+            "Machine capabilities already analysed",
+            "Load the trusted software catalogue",
+            "Read installed applications",
+            "Apply compatibility, installed-state and profile rules",
+            "Finalize the recommendation list"
+        ];
+
+        foreach (var labelText in labels)
+        {
+            var label = _recommendationLoadingCard
+                .GetLogicalDescendants()
+                .OfType<TextBlock>()
+                .FirstOrDefault(text => string.Equals(text.Text, labelText, StringComparison.Ordinal));
+
+            if (label?.Parent is not StackPanel row || row.Children.FirstOrDefault() is not TextBlock icon)
+            {
+                continue;
+            }
+
+            _recommendationProgressSteps.Add(new RecommendationProgressVisual(icon, label));
+        }
+    }
+
+    private void RecommendationProgressViewModel_OnPropertyChanged(
+        object? sender,
+        System.ComponentModel.PropertyChangedEventArgs args)
+    {
+        if (args.PropertyName is nameof(MainWindowViewModel.SelectedProfile))
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                ResetRecommendationProgress();
+                RefreshRecommendationLoadingCard();
+            });
+            return;
+        }
+
+        if (args.PropertyName is not nameof(MainWindowViewModel.IsBusy))
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (_viewModel.IsBusy && UsageProfilePanel.IsVisible)
+            {
+                _recommendationProgressFailed = false;
+                SetRecommendationProgressStage(RecommendationPipelineStage.LoadingTrustedCatalogue);
+                RefreshRecommendationLoadingCard();
+                return;
+            }
+
+            if (_viewModel.HasRecommendations)
+            {
+                CompleteRecommendationProgress();
+                _recommendationProgressFailed = false;
+                RefreshRecommendationLoadingCard();
+                return;
+            }
+
+            if (UsageProfilePanel.IsVisible &&
+                _activeRecommendationStage is not null &&
+                _viewModel.RecommendationStatus.Contains("could not", StringComparison.OrdinalIgnoreCase))
+            {
+                _recommendationProgressFailed = true;
+                FailCurrentRecommendationProgressStage();
+                RefreshRecommendationLoadingCard();
+                return;
+            }
+
+            _recommendationProgressFailed = false;
+            RefreshRecommendationLoadingCard();
+        });
+    }
+
+    private void OnRecommendationPipelineStageChanged(RecommendationPipelineStage stage)
+    {
+        if (!_viewModel.IsBusy || !UsageProfilePanel.IsVisible)
+        {
+            return;
+        }
+
+        SetRecommendationProgressStage(stage);
+    }
+
+    private void SetRecommendationProgressStage(RecommendationPipelineStage stage)
+    {
+        _activeRecommendationStage = stage;
+        _recommendationProgressFailed = false;
+        if (_recommendationProgressTitle is not null)
+        {
+            _recommendationProgressTitle.Text = "Building your recommendations";
+            _recommendationProgressTitle.Foreground = GuidanceTextBrush;
+        }
+
+        var activeIndex = stage switch
+        {
+            RecommendationPipelineStage.LoadingTrustedCatalogue => 1,
+            RecommendationPipelineStage.ReadingInstalledApplications => 2,
+            RecommendationPipelineStage.EvaluatingRecommendationRules => 3,
+            RecommendationPipelineStage.FinalizingRecommendations => 4,
+            _ => 1
+        };
+
+        for (var index = 0; index < _recommendationProgressSteps.Count; index++)
+        {
+            var state = index < activeIndex
+                ? RecommendationProgressVisualState.Completed
+                : index == activeIndex
+                    ? RecommendationProgressVisualState.Active
+                    : RecommendationProgressVisualState.Pending;
+            ApplyRecommendationProgressVisual(_recommendationProgressSteps[index], state);
+        }
+    }
+
+    private void CompleteRecommendationProgress()
+    {
+        _activeRecommendationStage = RecommendationPipelineStage.FinalizingRecommendations;
+        foreach (var step in _recommendationProgressSteps)
+        {
+            ApplyRecommendationProgressVisual(step, RecommendationProgressVisualState.Completed);
+        }
+    }
+
+    private void FailCurrentRecommendationProgressStage()
+    {
+        if (_recommendationProgressTitle is not null)
+        {
+            _recommendationProgressTitle.Text = "Recommendation build stopped";
+            _recommendationProgressTitle.Foreground = RecommendationProgressDangerBrush;
+        }
+
+        var activeIndex = _activeRecommendationStage switch
+        {
+            RecommendationPipelineStage.LoadingTrustedCatalogue => 1,
+            RecommendationPipelineStage.ReadingInstalledApplications => 2,
+            RecommendationPipelineStage.EvaluatingRecommendationRules => 3,
+            RecommendationPipelineStage.FinalizingRecommendations => 4,
+            _ => 1
+        };
+
+        for (var index = 0; index < _recommendationProgressSteps.Count; index++)
+        {
+            var state = index < activeIndex
+                ? RecommendationProgressVisualState.Completed
+                : index == activeIndex
+                    ? RecommendationProgressVisualState.Failed
+                    : RecommendationProgressVisualState.Pending;
+            ApplyRecommendationProgressVisual(_recommendationProgressSteps[index], state);
+        }
+    }
+
+    private void ResetRecommendationProgress()
+    {
+        _activeRecommendationStage = null;
+        _recommendationProgressFailed = false;
+
+        if (_recommendationProgressTitle is not null)
+        {
+            _recommendationProgressTitle.Text = "Building your recommendations";
+            _recommendationProgressTitle.Foreground = GuidanceTextBrush;
+        }
+
+        for (var index = 0; index < _recommendationProgressSteps.Count; index++)
+        {
+            ApplyRecommendationProgressVisual(
+                _recommendationProgressSteps[index],
+                index == 0
+                    ? RecommendationProgressVisualState.Completed
+                    : RecommendationProgressVisualState.Pending);
+        }
+    }
+
+    private static void ApplyRecommendationProgressVisual(
+        RecommendationProgressVisual visual,
+        RecommendationProgressVisualState state)
+    {
+        switch (state)
+        {
+            case RecommendationProgressVisualState.Completed:
+                visual.Icon.Text = "✓";
+                visual.Icon.Foreground = SuccessBrush;
+                visual.Label.Foreground = SuccessBrush;
+                visual.Label.FontWeight = FontWeight.Normal;
+                break;
+            case RecommendationProgressVisualState.Active:
+                visual.Icon.Text = "●";
+                visual.Icon.Foreground = TealBrush;
+                visual.Label.Foreground = GuidanceTextBrush;
+                visual.Label.FontWeight = FontWeight.SemiBold;
+                break;
+            case RecommendationProgressVisualState.Failed:
+                visual.Icon.Text = "!";
+                visual.Icon.Foreground = RecommendationProgressDangerBrush;
+                visual.Label.Foreground = RecommendationProgressDangerBrush;
+                visual.Label.FontWeight = FontWeight.SemiBold;
+                break;
+            default:
+                visual.Icon.Text = "○";
+                visual.Icon.Foreground = GuidanceMutedBrush;
+                visual.Label.Foreground = GuidanceMutedBrush;
+                visual.Label.FontWeight = FontWeight.Normal;
+                break;
+        }
+    }
+
+    private sealed record RecommendationProgressVisual(TextBlock Icon, TextBlock Label);
+
+    private enum RecommendationProgressVisualState
+    {
+        Pending,
+        Active,
+        Completed,
+        Failed
+    }
+}

--- a/src/AgenStart.Desktop/Views/MainWindow.RecommendationProgress.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.RecommendationProgress.cs
@@ -32,7 +32,7 @@ public sealed partial class MainWindow
             Dispatcher.UIThread.Post(() => OnRecommendationPipelineStageChanged(stage)));
 
         _viewModel.PropertyChanged += RecommendationProgressViewModel_OnPropertyChanged;
-        Recommendations.CollectionChanged += (_, args) =>
+        _viewModel.Recommendations.CollectionChanged += (_, args) =>
         {
             if (_viewModel.IsBusy && UsageProfilePanel.IsVisible && args.NewItems is { Count: > 0 })
             {

--- a/src/AgenStart.Desktop/Views/MainWindow.UiPolish.cs
+++ b/src/AgenStart.Desktop/Views/MainWindow.UiPolish.cs
@@ -41,6 +41,7 @@ public sealed partial class MainWindow
         PolishUsageProfiles();
         AddProfileGuidance();
         AddRecommendationLoadingCard();
+        InstallRecommendationProgressTracking();
         RecommendationsPanel.LayoutUpdated += (_, _) => ApplyRecommendationStatusVisuals();
         _viewModel.PropertyChanged += (_, args) =>
         {
@@ -231,11 +232,10 @@ public sealed partial class MainWindow
 
         var steps = new StackPanel { Spacing = 8 };
         steps.Children.Add(BuildLoadingStep("✓", "Machine capabilities already analysed", SuccessBrush));
-        steps.Children.Add(BuildLoadingStep("○", "Read installed applications", TealBrush));
-        steps.Children.Add(BuildLoadingStep("○", "Load the trusted software catalogue", TealBrush));
-        steps.Children.Add(BuildLoadingStep("○", "Match apps to the selected usage profile", TealBrush));
-        steps.Children.Add(BuildLoadingStep("○", "Apply compatibility and installed-state rules", TealBrush));
-        steps.Children.Add(BuildLoadingStep("○", "Finalize the recommendation list", TealBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Load the trusted software catalogue", GuidanceMutedBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Read installed applications", GuidanceMutedBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Apply compatibility, installed-state and profile rules", GuidanceMutedBrush));
+        steps.Children.Add(BuildLoadingStep("○", "Finalize the recommendation list", GuidanceMutedBrush));
 
         var content = new StackPanel { Spacing = 10 };
         content.Children.Add(new TextBlock
@@ -247,16 +247,11 @@ public sealed partial class MainWindow
         });
         content.Children.Add(new TextBlock
         {
-            Text = "AgenStart is checking these inputs before showing your final list. No fake percentage is used.",
+            Text = "AgenStart shows the real pipeline phase currently in progress. No fake percentage is used.",
             FontSize = 13,
             Foreground = GuidanceMutedBrush,
-            TextWrapping = TextWrapping.Wrap
-        });
-        content.Children.Add(new ProgressBar
-        {
-            IsIndeterminate = true,
-            Height = 3,
-            Margin = new Avalonia.Thickness(0, 2, 0, 4)
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Avalonia.Thickness(0, 0, 0, 4)
         });
         content.Children.Add(steps);
 
@@ -290,7 +285,7 @@ public sealed partial class MainWindow
         row.Children.Add(new TextBlock
         {
             Text = text,
-            Foreground = GuidanceMutedBrush,
+            Foreground = brush,
             FontSize = 13,
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
         });
@@ -301,7 +296,8 @@ public sealed partial class MainWindow
     {
         if (_recommendationLoadingCard is not null)
         {
-            _recommendationLoadingCard.IsVisible = UsageProfilePanel.IsVisible && _viewModel.IsBusy;
+            _recommendationLoadingCard.IsVisible = UsageProfilePanel.IsVisible &&
+                                                   (_viewModel.IsBusy || _recommendationProgressFailed);
         }
     }
 

--- a/src/AgenStart.Platform.Windows/SoftwareInventory/WindowsInstalledSoftwareInventoryProvider.cs
+++ b/src/AgenStart.Platform.Windows/SoftwareInventory/WindowsInstalledSoftwareInventoryProvider.cs
@@ -1,3 +1,4 @@
+using AgenStart.Core.Recommendations;
 using AgenStart.SoftwareInventory;
 
 namespace AgenStart.Platform.Windows.SoftwareInventory;
@@ -24,7 +25,12 @@ public sealed class WindowsInstalledSoftwareInventoryProvider : IInstalledSoftwa
             timeProvider);
     }
 
-    public Task<InstalledSoftwareSnapshot> CaptureAsync(
-        CancellationToken cancellationToken = default) =>
-        _inner.CaptureAsync(cancellationToken);
+    public async Task<InstalledSoftwareSnapshot> CaptureAsync(
+        CancellationToken cancellationToken = default)
+    {
+        RecommendationPipelineDiagnostics.Report(RecommendationPipelineStage.ReadingInstalledApplications);
+        var snapshot = await _inner.CaptureAsync(cancellationToken).ConfigureAwait(false);
+        RecommendationPipelineDiagnostics.Report(RecommendationPipelineStage.ApplyingInstalledStateRules);
+        return snapshot;
+    }
 }

--- a/src/AgenStart.Platform.Windows/SoftwareInventory/WindowsInstalledSoftwareInventoryProvider.cs
+++ b/src/AgenStart.Platform.Windows/SoftwareInventory/WindowsInstalledSoftwareInventoryProvider.cs
@@ -30,7 +30,7 @@ public sealed class WindowsInstalledSoftwareInventoryProvider : IInstalledSoftwa
     {
         RecommendationPipelineDiagnostics.Report(RecommendationPipelineStage.ReadingInstalledApplications);
         var snapshot = await _inner.CaptureAsync(cancellationToken).ConfigureAwait(false);
-        RecommendationPipelineDiagnostics.Report(RecommendationPipelineStage.ApplyingInstalledStateRules);
+        RecommendationPipelineDiagnostics.Report(RecommendationPipelineStage.EvaluatingRecommendationRules);
         return snapshot;
     }
 }


### PR DESCRIPTION
## Summary

Replace the remaining vague recommendation-loading treatment with progress driven by observable pipeline milestones.

### UX
- remove the unexplained moving progress strip from recommendation generation
- show completed / current / pending states with check, active dot and neutral circle
- keep machine analysis visibly completed before recommendation work starts
- show the actual sequence used by AgenStart: trusted catalogue → installed apps → compatibility/installed-state/profile evaluation → finalization
- retain a failed-stage state when recommendation generation stops with an error
- no fake percentage and no artificial delay

### Engineering
- add a process-local `RecommendationPipelineDiagnostics` milestone channel in Core
- report installed-software start and post-inventory evaluation transition from the Windows inventory provider
- derive catalogue start from the real `IsBusy` transition and finalization from recommendation rows entering the collection
- diagnostic subscribers cannot break the recommendation pipeline

Closes #53