### PR TITLE
feat: add parallel package preparation pipeline

### DIFF
--- a/docs/architecture/installation-orchestrator.md
+++ b/docs/architecture/installation-orchestrator.md
@@ -1,10 +1,10 @@
-# Installation queue and execution orchestrator
+# Installation queue, package preparation and execution orchestrator
 
 ## Purpose
 
-Issue #7 introduces the application-layer execution boundary that turns a user-approved software selection into a controlled installation session.
+The application-layer installation boundary turns a user-approved software selection into a controlled installation session.
 
-The orchestrator does not execute shell commands and does not know WinGet arguments. It consumes only the typed `IPackageProvider` contract introduced by #4 and the normalized installed-software state introduced by #5.
+The orchestrator does not construct shell commands and does not know WinGet command-line arguments. It consumes typed package-provider contracts and normalized installed-software state.
 
 ```text
 User-approved selection
@@ -14,22 +14,22 @@ InstallationOrchestrator
         |
         +--> IInstallationVerifier --> normalized software inventory
         |
-        `--> IPackageProvider -------> WinGetProvider (Windows V1)
+        `--> IPackageProvider
+                |
+                +--> Resolve exact trusted package
+                +--> optional bounded preparation
+                `--> sequential installer execution
 ```
-
-The UI remains outside this boundary. It observes session state and progress events and may request cancellation or an explicit retry.
 
 ## Approval boundary
 
-Only selections with `Approved = true` enter the executable queue.
+Only selections with `Approved = true` enter the executable queue. Non-approved selections remain in the final report as `Skipped`.
 
-Non-approved selections are retained in the session report as `Skipped` with diagnostic code `selection.not-approved`. This makes the final report complete while preserving the security/product rule that AgenStart never installs a recommendation merely because it was suggested.
+AgenStart never installs a recommendation merely because it was suggested.
 
-## Queue model
+## Two-layer state model
 
-V1 executes sequentially.
-
-Item states:
+Terminal queue state remains intentionally small:
 
 ```text
 Queued
@@ -40,44 +40,108 @@ Skipped
 Cancelled
 ```
 
-Session states:
+A separate activity state explains what an item is doing while it is still in the queue:
 
 ```text
+Waiting
+Resolving
+Downloading
 Ready
-Running
-Cancelling
+Installing
+Verifying
 Completed
+Failed
+Skipped
 Cancelled
 ```
 
-The session object is the in-memory source of truth for the active run. It preserves sequence, attempt count, provider result, verification result, retry eligibility, reboot requirement and timestamps.
+This separation lets the UI expose `Downloading`, `Ready` and `Installing` without weakening the deterministic queue/report model.
 
-Durable recovery across application restarts is deferred. "Persisted for the active session" in V1 means state is retained consistently in the active `InstallationSession`, not written to a long-lived machine database.
+## Bounded preparation pipeline
+
+AgenStart v0.2 can prepare trusted packages ahead of installation when a provider implements `IPreparablePackageProvider`.
+
+The default preparation concurrency is **3** and is constrained to **1–3**. Installer execution concurrency remains **exactly 1**.
+
+```text
+approved items
+     |
+     v
+pre-verification
+     |
+     v
+exact resolve
+     |
+     +---- preparation worker 1 ---- Downloading -> Ready
+     +---- preparation worker 2 ---- Downloading -> Ready
+     `---- preparation worker 3 ---- Downloading -> Ready
+                                      |
+                                      v
+                           deterministic sequence
+                                      |
+                                      v
+                             Installing (one only)
+                                      |
+                                      v
+                                  Verifying
+```
+
+Preparation failures are item-local. A failed download does not corrupt or reorder other queue items.
+
+Providers that cannot safely prepare a package return `Unsupported`; the item remains eligible for the provider's normal trusted sequential installation path.
+
+## Windows / WinGet preparation
+
+For the public `winget` source, `WinGetProvider` may use `winget download` with:
+
+- exact package ID;
+- exact configured trusted source;
+- AgenStart-owned absolute download directory;
+- explicit package/source agreement flags only when the user approved them;
+- no force, override or hash-bypass flags.
+
+The Microsoft Store source is deliberately excluded from direct preparation in this version because its account/licensing flow remains owned by WinGet.
+
+After WinGet downloads a package, AgenStart:
+
+1. reads the WinGet-emitted merged manifest;
+2. matches the expected exact package identifier;
+3. requires the manifest installer SHA-256;
+4. independently re-hashes the downloaded installer;
+5. allows prepared execution only for a conservative set of installer types (`exe`, Inno, Nullsoft, Burn, MSI/Wix);
+6. falls back to normal WinGet installation when dependencies or safe silent invocation cannot be preserved;
+7. re-checks the installer SHA-256 immediately before execution.
+
+The public preparation result contains an opaque preparation ID, not an arbitrary executable path supplied by UI/user input.
+
+## Sequential installation guarantee
+
+Even while later packages are downloading, the orchestrator consumes ready items only in the original approved sequence.
+
+At most one call to `InstallAsync` or `InstallPreparedAsync` is active at a time. This avoids MSI/UAC/PATH/reboot-sensitive installer contention.
 
 ## Execution sequence
 
-For each approved queued item the orchestrator performs:
+For each approved item:
 
-1. mark item `Running` and increment attempt count;
-2. refresh installed-state verification before provider execution;
-3. if already installed, mark `Succeeded` with `AlreadyInstalled` and skip provider execution;
-4. locate the registered provider by exact provider ID;
-5. check provider availability;
-6. resolve the exact trusted package reference;
-7. call `IPackageProvider.InstallAsync` with the typed user-approved request;
-8. normalize cancellation/failure results;
-9. refresh installed-state verification after a verifiable provider completion;
-10. derive the final queue item state and publish progress.
+1. increment attempt count;
+2. refresh installed-state verification;
+3. skip provider execution if already installed;
+4. check the registered exact provider;
+5. resolve the exact trusted package reference;
+6. optionally prepare/download it using the bounded preparation pool;
+7. mark it `Ready`;
+8. execute it only when every earlier executable queue position has been consumed;
+9. mark `Verifying` and refresh installed state;
+10. derive the terminal queue state and publish progress.
 
-No fuzzy package lookup, source fallback, arbitrary command or shell execution is introduced by the orchestrator.
+No fuzzy package lookup, automatic source fallback or arbitrary provider argument injection is introduced by the orchestrator.
 
 ## Post-install verification
 
-Provider exit status alone is not enough to claim installation success.
+Provider exit status alone is not enough to claim success.
 
 `SoftwareInventoryInstallationVerifier` refreshes `IInstalledSoftwareInventoryProvider` and resolves the application through `SoftwareStateResolver`.
-
-Mapping:
 
 ```text
 Installed -> Verified
@@ -85,102 +149,77 @@ Missing   -> NotInstalled
 Unknown   -> Unknown
 ```
 
-A provider result of `Succeeded`, `AlreadyInstalled` or `RebootRequired` becomes final `Succeeded` only when installed state is verified.
-
-If the provider completed but inventory proves the application is still missing, the item becomes `Failed` and may be retried.
-
-If inventory is incomplete/ambiguous after a provider completion, the item becomes `Failed` with retry disabled. AgenStart deliberately avoids repeating an installation that may already have succeeded.
+A provider result becomes final `Succeeded` only after installed state is verified.
 
 ## Retry policy
 
-The provider layer performs no implicit retry. Retry policy belongs here.
+There is no implicit retry.
 
-Initial retryable provider states are limited to conditions that may reasonably change without changing package identity:
+Transient preparation/provider failures such as network failure, source unavailability, timeout or provider unavailability can be marked retryable. Retry remains explicit.
 
-```text
-NetworkFailure
-SourceUnavailable
-TimedOut
-ProviderUnavailable
-Failed
-```
+A prepared package may be retained for an explicit retry when the installer failed after preparation. Before any retry, installed-state verification runs again to prevent duplicate side effects.
 
-Retryable resolution states follow the same conservative principle.
-
-`RequiresElevation`, agreement failures, policy blocks, integrity failures, ambiguous packages and unsupported installers are not automatically retryable.
-
-A retry is always explicit. Before invoking the provider again, the orchestrator re-runs installed-state verification. If the package is now detected, the retry finishes as `Succeeded / AlreadyInstalled` without a second provider installation call.
-
-This protects against duplicate side effects when the previous installer completed but its original operation result or immediate verification was inconclusive.
+Integrity failures, policy blocks, ambiguous packages and agreement/elevation requirements are never silently bypassed.
 
 ## Cancellation semantics
 
-Cancellation is cooperative at the application layer and is propagated to provider operations through a linked `CancellationToken`.
+Cancellation is propagated through the linked session token to active preparation and provider operations.
 
 When cancellation is requested:
 
-- the active provider receives cancellation;
-- the current item becomes `Cancelled` when provider execution/resolution reports cancellation or throws due to the linked token;
-- all not-yet-started `Queued` items become `Cancelled`;
-- already `Succeeded`, `Failed` or `Skipped` items remain unchanged;
+- active downloads/preparation receive cancellation;
+- active installer execution receives cancellation;
+- not-yet-consumed queued items become `Cancelled`;
+- completed terminal items remain unchanged;
 - the session ends as `Cancelled`.
 
-A cancelled session cannot be resumed or retried in V1. The user creates a new session from a fresh approved selection instead.
+Prepared files that have already completed can be retained only while the active orchestrator needs them safely; successful verified installations release their preparation cache best-effort.
 
-## Progress and observability
+## Progress and UI contract
 
-`InstallationSession.ProgressChanged` publishes structured `InstallationProgressEvent` values containing:
+`InstallationSession.ProgressChanged` emits structured snapshots with activity, downloaded/required bytes when known, terminal state, retry eligibility and timestamps.
 
-- session ID and state;
-- item snapshot when applicable;
-- stable diagnostic/event code;
-- human-readable message;
-- UTC timestamp.
+The desktop UI can therefore distinguish:
 
-These events are suitable for the future Avalonia UI and for privacy-minimal local diagnostics. They are not telemetry by themselves.
+```text
+Resolving
+Downloading
+Ready
+Installing
+Verifying
+Verified / Failed / Cancelled
+```
 
-## Final report
-
-`InstallationReport` includes every original selection, including skipped items, with:
-
-- deterministic sequence;
-- application/package identity;
-- final state;
-- attempt count;
-- last normalized provider status;
-- diagnostic code/message;
-- installed version when verified;
-- retry eligibility;
-- reboot requirement;
-- start/completion timestamps.
-
-Summary counters expose succeeded, failed, skipped and cancelled totals.
+No fake percentage is required when a provider cannot expose trustworthy byte totals.
 
 ## Security properties
 
-The orchestrator preserves ADR-0002 and the #4 provider boundary:
+The pipeline preserves the existing trust boundary:
 
+- approved applications only;
+- exact typed provider/package/source identity;
+- trusted WinGet sources only;
+- no arbitrary installer URLs;
 - no `cmd.exe` or PowerShell command construction;
-- no arbitrary provider arguments;
-- no fuzzy execution-time package selection;
-- no automatic source fallback;
+- no `--override`, `--force` or security-hash bypass;
+- independent SHA-256 verification of prepared installers;
+- SHA-256 checked again immediately before prepared execution;
+- unsupported or unsafe preparation falls back to the normal WinGet path;
+- installer execution remains sequential;
 - no automatic elevation broker;
-- no implicit retry;
-- no installation of unapproved recommendations;
 - no success claim without post-install verification.
 
 ## Verification gate
 
-`Installation tests` runs on every relevant `push` and `pull_request`, plus manual dispatch.
+Installation and Windows provider tests cover:
 
-The test suite covers:
-
-- approved-only queue execution;
-- deterministic sequential order;
-- skipped non-approved items;
-- normalized retryable provider failure;
-- retry without duplicate installation;
-- session cancellation and cancellation of remaining queued items;
-- post-install unknown state not being claimed as success;
-- reboot-required success after verification;
-- real `SoftwareInventoryInstallationVerifier` mapping for installed and incomplete inventory states.
+- approved-only execution;
+- bounded concurrent preparation with at least two overlapping preparations;
+- sequential deterministic installation despite concurrent downloads;
+- isolated preparation failure;
+- cancellation before installer execution;
+- exact WinGet download command construction;
+- no security-bypass arguments;
+- prepared installer SHA-256 verification and tamper rejection;
+- Store preparation fallback;
+- existing retry, cancellation and post-install verification behavior.

--- a/src/AgenStart.Application/Installation/InstallationContracts.cs
+++ b/src/AgenStart.Application/Installation/InstallationContracts.cs
@@ -12,6 +12,20 @@ public enum InstallationQueueItemState
     Cancelled
 }
 
+public enum InstallationItemActivity
+{
+    Waiting = 0,
+    Resolving,
+    Downloading,
+    Ready,
+    Installing,
+    Verifying,
+    Completed,
+    Failed,
+    Skipped,
+    Cancelled
+}
+
 public enum InstallationSessionState
 {
     Ready,
@@ -54,6 +68,7 @@ public sealed record InstallationItemSnapshot(
     string ApplicationId,
     ProviderPackageReference Package,
     InstallationQueueItemState State,
+    InstallationItemActivity Activity,
     int AttemptCount,
     PackageOperationStatus? LastOperationStatus,
     string? DiagnosticCode,
@@ -61,6 +76,8 @@ public sealed record InstallationItemSnapshot(
     string? InstalledVersion,
     bool CanRetry,
     bool RequiresReboot,
+    long? BytesDownloaded,
+    long? BytesRequired,
     DateTimeOffset? StartedAtUtc,
     DateTimeOffset? CompletedAtUtc);
 

--- a/src/AgenStart.Application/Installation/InstallationOrchestrator.cs
+++ b/src/AgenStart.Application/Installation/InstallationOrchestrator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using AgenStart.PackageManagement;
 
 namespace AgenStart.Application.Installation;
@@ -7,15 +8,27 @@ public sealed class InstallationOrchestrator
     private readonly IReadOnlyDictionary<string, IPackageProvider> _providers;
     private readonly IInstallationVerifier _verifier;
     private readonly TimeProvider _timeProvider;
+    private readonly int _preparationConcurrency;
+    private readonly ConcurrentDictionary<string, PackagePreparationResult> _preparations =
+        new(StringComparer.OrdinalIgnoreCase);
 
     public InstallationOrchestrator(
         IEnumerable<IPackageProvider> providers,
         IInstallationVerifier verifier,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        int preparationConcurrency = 3)
     {
         ArgumentNullException.ThrowIfNull(providers);
         _verifier = verifier ?? throw new ArgumentNullException(nameof(verifier));
         _timeProvider = timeProvider ?? TimeProvider.System;
+        if (preparationConcurrency is < 1 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(preparationConcurrency),
+                "Package preparation concurrency must be between 1 and 3.");
+        }
+
+        _preparationConcurrency = preparationConcurrency;
 
         var providerMap = new Dictionary<string, IPackageProvider>(StringComparer.OrdinalIgnoreCase);
         foreach (var provider in providers)
@@ -37,6 +50,8 @@ public sealed class InstallationOrchestrator
         _providers = providerMap;
     }
 
+    public int PreparationConcurrency => _preparationConcurrency;
+
     public InstallationSession CreateSession(IReadOnlyList<InstallationSelection> selections) =>
         new(selections, _timeProvider);
 
@@ -47,11 +62,12 @@ public sealed class InstallationOrchestrator
         ArgumentNullException.ThrowIfNull(session);
         session.BeginRun();
 
-        using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+        using var pipelineCancellation = CancellationTokenSource.CreateLinkedTokenSource(
             session.CancellationToken,
             cancellationToken);
-        var token = linkedCancellation.Token;
+        var token = pipelineCancellation.Token;
         var cancelled = false;
+        var candidates = new List<InstallationSession.InstallationQueueItem>();
 
         foreach (var item in session.MutableItems)
         {
@@ -66,10 +82,95 @@ public sealed class InstallationOrchestrator
                 break;
             }
 
-            cancelled = await ExecuteItemAsync(session, item, token).ConfigureAwait(false);
+            session.BeginAttempt(item);
+
+            try
+            {
+                var preVerification = await _verifier
+                    .VerifyAsync(item.Selection.ApplicationId, token)
+                    .ConfigureAwait(false);
+
+                if (preVerification.Status == InstallationVerificationStatus.Verified)
+                {
+                    await ReleasePreparationForItemAsync(session, item).ConfigureAwait(false);
+                    session.MarkSucceeded(
+                        item,
+                        preVerification.InstalledVersion,
+                        PackageOperationStatus.AlreadyInstalled,
+                        requiresReboot: false,
+                        $"{item.Selection.ApplicationId} is already installed; provider execution was skipped.");
+                    continue;
+                }
+
+                candidates.Add(item);
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                cancelled = true;
+                break;
+            }
+            catch (Exception exception)
+            {
+                session.MarkFailed(
+                    item,
+                    "installation.preverification-failed",
+                    $"Installed-state verification failed unexpectedly: {exception.GetType().Name}.",
+                    canRetry: false,
+                    PackageOperationStatus.Failed);
+            }
+        }
+
+        var preparationTasks = new Dictionary<string, Task<bool>>(StringComparer.OrdinalIgnoreCase);
+        if (!cancelled && candidates.Count > 0)
+        {
+            using var preparationGate = new SemaphoreSlim(_preparationConcurrency, _preparationConcurrency);
+            var availabilityTasks = new ConcurrentDictionary<string, Task<PackageProviderAvailability>>(
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (var item in candidates)
+            {
+                preparationTasks[item.Selection.ApplicationId] = PrepareItemAsync(
+                    session,
+                    item,
+                    preparationGate,
+                    availabilityTasks,
+                    token);
+            }
+
+            foreach (var item in candidates)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    cancelled = true;
+                    break;
+                }
+
+                var preparationCancelled = await preparationTasks[item.Selection.ApplicationId]
+                    .ConfigureAwait(false);
+                if (preparationCancelled)
+                {
+                    cancelled = true;
+                    pipelineCancellation.Cancel();
+                    break;
+                }
+
+                if (item.State != InstallationQueueItemState.Queued ||
+                    item.Activity != InstallationItemActivity.Ready)
+                {
+                    continue;
+                }
+
+                cancelled = await ExecuteReadyItemAsync(session, item, token).ConfigureAwait(false);
+                if (cancelled)
+                {
+                    pipelineCancellation.Cancel();
+                    break;
+                }
+            }
+
             if (cancelled)
             {
-                break;
+                await ObservePreparationTasksAsync(preparationTasks.Values).ConfigureAwait(false);
             }
         }
 
@@ -103,29 +204,34 @@ public sealed class InstallationOrchestrator
         return await RunAsync(session, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<bool> ExecuteItemAsync(
+    private async Task<bool> PrepareItemAsync(
         InstallationSession session,
         InstallationSession.InstallationQueueItem item,
+        SemaphoreSlim preparationGate,
+        ConcurrentDictionary<string, Task<PackageProviderAvailability>> availabilityTasks,
         CancellationToken cancellationToken)
     {
-        session.MarkRunning(item);
+        try
+        {
+            await preparationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return true;
+        }
 
         try
         {
-            var preVerification = await _verifier
-                .VerifyAsync(item.Selection.ApplicationId, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (preVerification.Status == InstallationVerificationStatus.Verified)
+            if (TryGetPreparation(session, item, out var cachedPreparation) && cachedPreparation.IsReady)
             {
-                session.MarkSucceeded(
+                session.MarkReady(
                     item,
-                    preVerification.InstalledVersion,
-                    PackageOperationStatus.AlreadyInstalled,
-                    requiresReboot: false,
-                    $"{item.Selection.ApplicationId} is already installed; provider execution was skipped.");
+                    cachedPreparation.BytesDownloaded,
+                    $"{item.Selection.ApplicationId} is already prepared and ready to install.");
                 return false;
             }
+
+            session.MarkResolving(item);
 
             if (!_providers.TryGetValue(item.Selection.Package.ProviderId, out var provider))
             {
@@ -138,9 +244,10 @@ public sealed class InstallationOrchestrator
                 return false;
             }
 
-            var availability = await provider
-                .CheckAvailabilityAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var availabilityTask = availabilityTasks.GetOrAdd(
+                provider.ProviderId,
+                _ => provider.CheckAvailabilityAsync(cancellationToken));
+            var availability = await availabilityTask.ConfigureAwait(false);
 
             if (!availability.IsAvailable)
             {
@@ -178,16 +285,117 @@ public sealed class InstallationOrchestrator
                 return false;
             }
 
-            var operation = await provider
-                .InstallAsync(
-                    new PackageInstallRequest(
-                        item.Selection.ApplicationId,
-                        item.Selection.Package,
-                        item.Selection.Silent,
-                        item.Selection.AcceptPackageAgreements,
-                        item.Selection.AcceptSourceAgreements),
-                    cancellationToken)
+            if (provider is not IPreparablePackageProvider preparable ||
+                !preparable.CanPrepare(item.Selection.Package))
+            {
+                session.MarkReady(
+                    item,
+                    message: $"{item.Selection.ApplicationId} is resolved and ready for sequential installation.");
+                return false;
+            }
+
+            session.MarkDownloading(item);
+            var request = CreateInstallRequest(item.Selection);
+            var progress = new CallbackProgress<PackagePreparationProgress>(value =>
+                session.UpdateDownloadProgress(item, value));
+            var preparation = await preparable
+                .PrepareAsync(request, progress, cancellationToken)
                 .ConfigureAwait(false);
+
+            if (preparation.Status == PackagePreparationStatus.Cancelled)
+            {
+                session.MarkCancelled(
+                    item,
+                    preparation.DiagnosticCode ?? "installation.download-cancelled",
+                    preparation.Message ?? "Package preparation was cancelled.",
+                    PackageOperationStatus.Cancelled);
+                return true;
+            }
+
+            if (preparation.Status == PackagePreparationStatus.Unsupported)
+            {
+                session.MarkReady(
+                    item,
+                    message: preparation.Message ??
+                        $"{item.Selection.ApplicationId} will use the provider's normal sequential install path.");
+                return false;
+            }
+
+            if (!preparation.IsReady)
+            {
+                session.MarkFailed(
+                    item,
+                    preparation.DiagnosticCode ?? "installation.package-preparation-failed",
+                    preparation.Message ?? $"Package {item.Selection.Package.PackageId} could not be prepared.",
+                    CanRetryPreparation(preparation.Status),
+                    MapPreparationStatus(preparation.Status));
+                return false;
+            }
+
+            _preparations[PreparationKey(session, item.Selection.ApplicationId)] = preparation;
+            session.MarkReady(
+                item,
+                preparation.BytesDownloaded,
+                preparation.Message ?? $"{item.Selection.ApplicationId} is downloaded and ready to install.");
+            return false;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return true;
+        }
+        catch (Exception exception)
+        {
+            session.MarkFailed(
+                item,
+                "installation.unhandled-preparation-error",
+                $"Package preparation failed unexpectedly: {exception.GetType().Name}.",
+                canRetry: false,
+                PackageOperationStatus.Failed);
+            return false;
+        }
+        finally
+        {
+            preparationGate.Release();
+        }
+    }
+
+    private async Task<bool> ExecuteReadyItemAsync(
+        InstallationSession session,
+        InstallationSession.InstallationQueueItem item,
+        CancellationToken cancellationToken)
+    {
+        session.MarkInstalling(item);
+
+        try
+        {
+            if (!_providers.TryGetValue(item.Selection.Package.ProviderId, out var provider))
+            {
+                session.MarkFailed(
+                    item,
+                    "installation.provider-not-registered",
+                    $"Provider {item.Selection.Package.ProviderId} is not registered for this session.",
+                    canRetry: false,
+                    PackageOperationStatus.ProviderUnavailable);
+                return false;
+            }
+
+            var request = CreateInstallRequest(item.Selection);
+            PackageOperationResult operation;
+
+            if (provider is IPreparablePackageProvider preparable &&
+                TryGetPreparation(session, item, out var preparation) &&
+                preparation.IsReady)
+            {
+                operation = await preparable
+                    .InstallPreparedAsync(request, preparation, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                operation = await provider
+                    .InstallAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
             if (operation.Status is PackageOperationStatus.Cancelled or PackageOperationStatus.CancelledByUser)
             {
@@ -210,6 +418,7 @@ public sealed class InstallationOrchestrator
                 return false;
             }
 
+            session.MarkVerifying(item);
             var verification = await _verifier
                 .VerifyAsync(item.Selection.ApplicationId, cancellationToken)
                 .ConfigureAwait(false);
@@ -222,6 +431,7 @@ public sealed class InstallationOrchestrator
                     operation.Status,
                     operation.Status == PackageOperationStatus.RebootRequired,
                     verification.Message);
+                await ReleasePreparationForItemAsync(session, item).ConfigureAwait(false);
                 return false;
             }
 
@@ -242,6 +452,7 @@ public sealed class InstallationOrchestrator
                 verification.Message ?? "Installation completed, but installed state could not be verified safely.",
                 canRetry: false,
                 operation.Status);
+            await ReleasePreparationForItemAsync(session, item).ConfigureAwait(false);
             return false;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -265,6 +476,60 @@ public sealed class InstallationOrchestrator
         }
     }
 
+    private async Task ReleasePreparationForItemAsync(
+        InstallationSession session,
+        InstallationSession.InstallationQueueItem item)
+    {
+        var key = PreparationKey(session, item.Selection.ApplicationId);
+        if (!_preparations.TryRemove(key, out var preparation) ||
+            !_providers.TryGetValue(item.Selection.Package.ProviderId, out var provider) ||
+            provider is not IPreparablePackageProvider preparable)
+        {
+            return;
+        }
+
+        try
+        {
+            await preparable.ReleasePreparationAsync(preparation, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // Cache cleanup is best-effort and must never turn a verified installation into a failure.
+        }
+    }
+
+    private bool TryGetPreparation(
+        InstallationSession session,
+        InstallationSession.InstallationQueueItem item,
+        out PackagePreparationResult preparation) =>
+        _preparations.TryGetValue(
+            PreparationKey(session, item.Selection.ApplicationId),
+            out preparation!);
+
+    private static string PreparationKey(InstallationSession session, string applicationId) =>
+        $"{session.SessionId:N}:{applicationId.Trim().ToLowerInvariant()}";
+
+    private static PackageInstallRequest CreateInstallRequest(InstallationSelection selection) =>
+        new(
+            selection.ApplicationId,
+            selection.Package,
+            selection.Silent,
+            selection.AcceptPackageAgreements,
+            selection.AcceptSourceAgreements);
+
+    private static async Task ObservePreparationTasksAsync(IEnumerable<Task<bool>> tasks)
+    {
+        try
+        {
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is represented in the installation session state.
+        }
+    }
+
     private static bool IsVerifiableCompletion(PackageOperationStatus status) =>
         status is PackageOperationStatus.Succeeded
             or PackageOperationStatus.AlreadyInstalled
@@ -279,6 +544,13 @@ public sealed class InstallationOrchestrator
             or PackageResolutionStatus.TimedOut
             or PackageResolutionStatus.ProviderUnavailable
             or PackageResolutionStatus.Failed;
+
+    private static bool CanRetryPreparation(PackagePreparationStatus status) =>
+        status is PackagePreparationStatus.NetworkFailure
+            or PackagePreparationStatus.SourceUnavailable
+            or PackagePreparationStatus.TimedOut
+            or PackagePreparationStatus.ProviderUnavailable
+            or PackagePreparationStatus.Failed;
 
     private static bool CanRetryOperation(PackageOperationStatus status) =>
         status is PackageOperationStatus.NetworkFailure
@@ -303,4 +575,24 @@ public sealed class InstallationOrchestrator
             PackageResolutionStatus.Failed => PackageOperationStatus.Failed,
             _ => null
         };
+
+    private static PackageOperationStatus? MapPreparationStatus(PackagePreparationStatus status) =>
+        status switch
+        {
+            PackagePreparationStatus.SourceUnavailable => PackageOperationStatus.SourceUnavailable,
+            PackagePreparationStatus.AgreementRequired => PackageOperationStatus.AgreementRequired,
+            PackagePreparationStatus.BlockedByPolicy => PackageOperationStatus.BlockedByPolicy,
+            PackagePreparationStatus.IntegrityFailure => PackageOperationStatus.IntegrityFailure,
+            PackagePreparationStatus.NetworkFailure => PackageOperationStatus.NetworkFailure,
+            PackagePreparationStatus.Cancelled => PackageOperationStatus.Cancelled,
+            PackagePreparationStatus.TimedOut => PackageOperationStatus.TimedOut,
+            PackagePreparationStatus.ProviderUnavailable => PackageOperationStatus.ProviderUnavailable,
+            PackagePreparationStatus.Failed => PackageOperationStatus.Failed,
+            _ => null
+        };
+
+    private sealed class CallbackProgress<T>(Action<T> callback) : IProgress<T>
+    {
+        public void Report(T value) => callback(value);
+    }
 }

--- a/src/AgenStart.Application/Installation/InstallationSession.cs
+++ b/src/AgenStart.Application/Installation/InstallationSession.cs
@@ -50,6 +50,9 @@ public sealed class InstallationSession : IDisposable
                 selection.Approved
                     ? InstallationQueueItemState.Queued
                     : InstallationQueueItemState.Skipped,
+                selection.Approved
+                    ? InstallationItemActivity.Waiting
+                    : InstallationItemActivity.Skipped,
                 selection.Approved ? null : "selection.not-approved",
                 selection.Approved
                     ? null
@@ -160,6 +163,7 @@ public sealed class InstallationSession : IDisposable
         }
 
         item.State = InstallationQueueItemState.Queued;
+        item.Activity = InstallationItemActivity.Waiting;
         item.DiagnosticCode = null;
         item.Message = null;
         item.CanRetry = false;
@@ -173,6 +177,7 @@ public sealed class InstallationSession : IDisposable
         foreach (var item in _items.Where(static item => item.State == InstallationQueueItemState.Queued))
         {
             item.State = InstallationQueueItemState.Cancelled;
+            item.Activity = InstallationItemActivity.Cancelled;
             item.CanRetry = false;
             item.DiagnosticCode = code;
             item.Message = message;
@@ -181,16 +186,82 @@ public sealed class InstallationSession : IDisposable
         }
     }
 
-    internal void MarkRunning(InstallationQueueItem item)
+    internal void BeginAttempt(InstallationQueueItem item)
     {
-        item.State = InstallationQueueItemState.Running;
         item.AttemptCount++;
         item.StartedAtUtc = _timeProvider.GetUtcNow();
         item.CompletedAtUtc = null;
         item.DiagnosticCode = null;
         item.Message = null;
         item.CanRetry = false;
-        Publish(item, "item.running", $"Installing {item.Selection.ApplicationId}.");
+        item.RequiresReboot = false;
+    }
+
+    internal void MarkResolving(InstallationQueueItem item)
+    {
+        item.Activity = InstallationItemActivity.Resolving;
+        Publish(item, "item.resolving", $"Resolving trusted package for {item.Selection.ApplicationId}.");
+    }
+
+    internal void MarkDownloading(InstallationQueueItem item)
+    {
+        item.Activity = InstallationItemActivity.Downloading;
+        item.BytesDownloaded = 0;
+        item.BytesRequired = null;
+        Publish(item, "item.downloading", $"Downloading {item.Selection.ApplicationId} from its trusted provider.");
+    }
+
+    internal void UpdateDownloadProgress(
+        InstallationQueueItem item,
+        PackagePreparationProgress progress)
+    {
+        item.Activity = InstallationItemActivity.Downloading;
+        if (progress.BytesDownloaded is not null)
+        {
+            item.BytesDownloaded = Math.Max(0, progress.BytesDownloaded.Value);
+        }
+
+        if (progress.BytesRequired is not null)
+        {
+            item.BytesRequired = Math.Max(0, progress.BytesRequired.Value);
+        }
+
+        Publish(
+            item,
+            "item.download-progress",
+            progress.Message ?? $"Downloading {item.Selection.ApplicationId}.");
+    }
+
+    internal void MarkReady(
+        InstallationQueueItem item,
+        long? bytesDownloaded = null,
+        string? message = null)
+    {
+        item.Activity = InstallationItemActivity.Ready;
+        if (bytesDownloaded is not null)
+        {
+            item.BytesDownloaded = Math.Max(0, bytesDownloaded.Value);
+        }
+
+        Publish(
+            item,
+            "item.ready",
+            message ?? $"{item.Selection.ApplicationId} is ready to install.");
+    }
+
+    internal void MarkInstalling(InstallationQueueItem item)
+    {
+        item.State = InstallationQueueItemState.Running;
+        item.Activity = InstallationItemActivity.Installing;
+        Publish(item, "item.installing", $"Installing {item.Selection.ApplicationId}.");
+    }
+
+    internal void MarkRunning(InstallationQueueItem item) => MarkInstalling(item);
+
+    internal void MarkVerifying(InstallationQueueItem item)
+    {
+        item.Activity = InstallationItemActivity.Verifying;
+        Publish(item, "item.verifying", $"Verifying {item.Selection.ApplicationId} after installation.");
     }
 
     internal void MarkSucceeded(
@@ -201,6 +272,7 @@ public sealed class InstallationSession : IDisposable
         string? message = null)
     {
         item.State = InstallationQueueItemState.Succeeded;
+        item.Activity = InstallationItemActivity.Completed;
         item.LastOperationStatus = operationStatus;
         item.InstalledVersion = installedVersion;
         item.CanRetry = false;
@@ -221,6 +293,7 @@ public sealed class InstallationSession : IDisposable
         PackageOperationStatus? operationStatus = null)
     {
         item.State = InstallationQueueItemState.Failed;
+        item.Activity = InstallationItemActivity.Failed;
         item.LastOperationStatus = operationStatus;
         item.DiagnosticCode = code;
         item.Message = message;
@@ -236,6 +309,7 @@ public sealed class InstallationSession : IDisposable
         PackageOperationStatus? operationStatus = null)
     {
         item.State = InstallationQueueItemState.Cancelled;
+        item.Activity = InstallationItemActivity.Cancelled;
         item.LastOperationStatus = operationStatus;
         item.DiagnosticCode = code;
         item.Message = message;
@@ -278,12 +352,14 @@ public sealed class InstallationSession : IDisposable
         int sequence,
         InstallationSelection selection,
         InstallationQueueItemState state,
+        InstallationItemActivity activity,
         string? diagnosticCode,
         string? message)
     {
         public int Sequence { get; } = sequence;
         public InstallationSelection Selection { get; } = selection;
         public InstallationQueueItemState State { get; set; } = state;
+        public InstallationItemActivity Activity { get; set; } = activity;
         public int AttemptCount { get; set; }
         public PackageOperationStatus? LastOperationStatus { get; set; }
         public string? DiagnosticCode { get; set; } = diagnosticCode;
@@ -291,6 +367,8 @@ public sealed class InstallationSession : IDisposable
         public string? InstalledVersion { get; set; }
         public bool CanRetry { get; set; }
         public bool RequiresReboot { get; set; }
+        public long? BytesDownloaded { get; set; }
+        public long? BytesRequired { get; set; }
         public DateTimeOffset? StartedAtUtc { get; set; }
         public DateTimeOffset? CompletedAtUtc { get; set; }
 
@@ -300,6 +378,7 @@ public sealed class InstallationSession : IDisposable
                 Selection.ApplicationId,
                 Selection.Package,
                 State,
+                Activity,
                 AttemptCount,
                 LastOperationStatus,
                 DiagnosticCode,
@@ -307,6 +386,8 @@ public sealed class InstallationSession : IDisposable
                 InstalledVersion,
                 CanRetry,
                 RequiresReboot,
+                BytesDownloaded,
+                BytesRequired,
                 StartedAtUtc,
                 CompletedAtUtc);
     }

--- a/src/AgenStart.Desktop/ViewModels/InstallationFlowRows.cs
+++ b/src/AgenStart.Desktop/ViewModels/InstallationFlowRows.cs
@@ -36,11 +36,14 @@ public sealed class ReviewRowViewModel
 public sealed class InstallationRowViewModel : INotifyPropertyChanged
 {
     private InstallationQueueItemState _state;
+    private InstallationItemActivity _activity;
     private string _status = "Waiting";
     private string? _message;
     private bool _canRetry;
     private string? _installedVersion;
     private bool _requiresReboot;
+    private long? _bytesDownloaded;
+    private long? _bytesRequired;
 
     public InstallationRowViewModel(string applicationId, string name, string initials)
     {
@@ -59,6 +62,12 @@ public sealed class InstallationRowViewModel : INotifyPropertyChanged
     {
         get => _state;
         private set => SetField(ref _state, value);
+    }
+
+    public InstallationItemActivity Activity
+    {
+        get => _activity;
+        private set => SetField(ref _activity, value);
     }
 
     public string Status
@@ -91,29 +100,119 @@ public sealed class InstallationRowViewModel : INotifyPropertyChanged
         private set => SetField(ref _requiresReboot, value);
     }
 
+    public long? BytesDownloaded
+    {
+        get => _bytesDownloaded;
+        private set => SetField(ref _bytesDownloaded, value);
+    }
+
+    public long? BytesRequired
+    {
+        get => _bytesRequired;
+        private set => SetField(ref _bytesRequired, value);
+    }
+
     public bool IsRunning => State == InstallationQueueItemState.Running;
+    public bool IsDownloading => Activity == InstallationItemActivity.Downloading;
+    public bool IsReady => Activity == InstallationItemActivity.Ready;
+    public bool IsInstalling => Activity == InstallationItemActivity.Installing;
     public bool HasFailure => State == InstallationQueueItemState.Failed;
+
+    public string DownloadDetail => Activity == InstallationItemActivity.Downloading
+        ? FormatDownloadDetail(BytesDownloaded, BytesRequired)
+        : string.Empty;
 
     public void Apply(InstallationItemSnapshot snapshot)
     {
         State = snapshot.State;
-        Status = snapshot.State switch
-        {
-            InstallationQueueItemState.Queued => "Waiting",
-            InstallationQueueItemState.Running => "Installing",
-            InstallationQueueItemState.Succeeded when snapshot.LastOperationStatus == PackageOperationStatus.AlreadyInstalled => "Already installed",
-            InstallationQueueItemState.Succeeded => snapshot.RequiresReboot ? "Installed · restart required" : "Installed",
-            InstallationQueueItemState.Failed => "Failed",
-            InstallationQueueItemState.Skipped => "Skipped",
-            InstallationQueueItemState.Cancelled => "Cancelled",
-            _ => snapshot.State.ToString()
-        };
+        Activity = snapshot.Activity;
+        BytesDownloaded = snapshot.BytesDownloaded;
+        BytesRequired = snapshot.BytesRequired;
+        Status = ResolveStatus(snapshot);
         Message = snapshot.Message;
         CanRetry = snapshot.CanRetry;
         InstalledVersion = snapshot.InstalledVersion;
         RequiresReboot = snapshot.RequiresReboot;
         OnPropertyChanged(nameof(IsRunning));
+        OnPropertyChanged(nameof(IsDownloading));
+        OnPropertyChanged(nameof(IsReady));
+        OnPropertyChanged(nameof(IsInstalling));
         OnPropertyChanged(nameof(HasFailure));
+        OnPropertyChanged(nameof(DownloadDetail));
+    }
+
+    private static string ResolveStatus(InstallationItemSnapshot snapshot)
+    {
+        if (snapshot.State == InstallationQueueItemState.Succeeded &&
+            snapshot.LastOperationStatus == PackageOperationStatus.AlreadyInstalled)
+        {
+            return "Already installed";
+        }
+
+        if (snapshot.State == InstallationQueueItemState.Succeeded)
+        {
+            return snapshot.RequiresReboot ? "Verified · restart required" : "Verified";
+        }
+
+        if (snapshot.State == InstallationQueueItemState.Failed)
+        {
+            return "Failed";
+        }
+
+        if (snapshot.State == InstallationQueueItemState.Skipped)
+        {
+            return "Skipped";
+        }
+
+        if (snapshot.State == InstallationQueueItemState.Cancelled)
+        {
+            return "Cancelled";
+        }
+
+        return snapshot.Activity switch
+        {
+            InstallationItemActivity.Resolving => "Resolving",
+            InstallationItemActivity.Downloading => "Downloading",
+            InstallationItemActivity.Ready => "Ready",
+            InstallationItemActivity.Installing => "Installing",
+            InstallationItemActivity.Verifying => "Verifying",
+            _ => "Waiting"
+        };
+    }
+
+    private static string FormatDownloadDetail(long? downloaded, long? required)
+    {
+        if (downloaded is null)
+        {
+            return "Downloading through trusted provider";
+        }
+
+        if (required is > 0)
+        {
+            return $"{FormatBytes(downloaded.Value)} / {FormatBytes(required.Value)}";
+        }
+
+        return $"{FormatBytes(downloaded.Value)} downloaded";
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes >= 1024L * 1024 * 1024)
+        {
+            return $"{bytes / (1024d * 1024 * 1024):0.0} GB";
+        }
+
+        if (bytes >= 1024L * 1024)
+        {
+            return $"{bytes / (1024d * 1024):0.0} MB";
+        }
+
+        if (bytes >= 1024)
+        {
+            return $"{bytes / 1024d:0.0} KB";
+        }
+
+        return $"{bytes} B";
     }
 
     private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)

--- a/src/AgenStart.PackageManagement/PackageProviderContracts.cs
+++ b/src/AgenStart.PackageManagement/PackageProviderContracts.cs
@@ -26,6 +26,39 @@ public sealed record PackageInstallRequest(
     bool AcceptPackageAgreements = false,
     bool AcceptSourceAgreements = false);
 
+public enum PackagePreparationStatus
+{
+    Ready = 0,
+    Unsupported,
+    SourceUnavailable,
+    AgreementRequired,
+    BlockedByPolicy,
+    IntegrityFailure,
+    NetworkFailure,
+    Cancelled,
+    TimedOut,
+    ProviderUnavailable,
+    Failed
+}
+
+public sealed record PackagePreparationProgress(
+    long? BytesDownloaded = null,
+    long? BytesRequired = null,
+    double? Fraction = null,
+    string? Message = null);
+
+public sealed record PackagePreparationResult(
+    PackagePreparationStatus Status,
+    string ApplicationId,
+    ProviderPackageReference Package,
+    string? PreparationId = null,
+    long? BytesDownloaded = null,
+    string? DiagnosticCode = null,
+    string? Message = null)
+{
+    public bool IsReady => Status == PackagePreparationStatus.Ready && !string.IsNullOrWhiteSpace(PreparationId);
+}
+
 public enum PackageProviderAvailabilityStatus
 {
     Available = 0,
@@ -113,5 +146,24 @@ public interface IPackageProvider
 
     Task<PackageOperationResult> InstallAsync(
         PackageInstallRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public interface IPreparablePackageProvider : IPackageProvider
+{
+    bool CanPrepare(ProviderPackageReference package);
+
+    Task<PackagePreparationResult> PrepareAsync(
+        PackageInstallRequest request,
+        IProgress<PackagePreparationProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    Task<PackageOperationResult> InstallPreparedAsync(
+        PackageInstallRequest request,
+        PackagePreparationResult preparation,
+        CancellationToken cancellationToken = default);
+
+    Task ReleasePreparationAsync(
+        PackagePreparationResult preparation,
         CancellationToken cancellationToken = default);
 }

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetCommandBuilder.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetCommandBuilder.cs
@@ -52,6 +52,47 @@ public static partial class WinGetCommandBuilder
         ]);
     }
 
+    public static WinGetCommand BuildDownload(
+        PackageInstallRequest request,
+        string downloadDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateApplicationId(request.ApplicationId);
+        ValidateReference(request.Package);
+        ArgumentException.ThrowIfNullOrWhiteSpace(downloadDirectory);
+
+        if (!Path.IsPathFullyQualified(downloadDirectory))
+        {
+            throw new ArgumentException(
+                "WinGet download output must be an AgenStart-owned absolute path.",
+                nameof(downloadDirectory));
+        }
+
+        var arguments = new List<string>
+        {
+            "download",
+            "--id", request.Package.PackageId,
+            "--exact",
+            "--source", request.Package.Source,
+            "--download-directory", downloadDirectory,
+            "--disable-interactivity"
+        };
+
+        AddScope(arguments, request.Package.ScopePreference, nameof(request));
+
+        if (request.AcceptPackageAgreements)
+        {
+            arguments.Add("--accept-package-agreements");
+        }
+
+        if (request.AcceptSourceAgreements)
+        {
+            arguments.Add("--accept-source-agreements");
+        }
+
+        return new WinGetCommand(arguments);
+    }
+
     public static WinGetCommand BuildInstall(PackageInstallRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -68,24 +109,7 @@ public static partial class WinGetCommandBuilder
             "--no-upgrade"
         };
 
-        switch (request.Package.ScopePreference)
-        {
-            case PackageScope.User:
-                arguments.Add("--scope");
-                arguments.Add("user");
-                break;
-            case PackageScope.Machine:
-                arguments.Add("--scope");
-                arguments.Add("machine");
-                break;
-            case PackageScope.Default:
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(
-                    nameof(request),
-                    request.Package.ScopePreference,
-                    "Unsupported package scope.");
-        }
+        AddScope(arguments, request.Package.ScopePreference, nameof(request));
 
         if (request.Silent)
         {
@@ -124,6 +148,31 @@ public static partial class WinGetCommandBuilder
         }
 
         ValidateSource(package.Source);
+    }
+
+    private static void AddScope(
+        List<string> arguments,
+        PackageScope scope,
+        string parameterName)
+    {
+        switch (scope)
+        {
+            case PackageScope.User:
+                arguments.Add("--scope");
+                arguments.Add("user");
+                break;
+            case PackageScope.Machine:
+                arguments.Add("--scope");
+                arguments.Add("machine");
+                break;
+            case PackageScope.Default:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    parameterName,
+                    scope,
+                    "Unsupported package scope.");
+        }
     }
 
     private static void ValidateSource(string source)

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetPreparedPackage.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetPreparedPackage.cs
@@ -1,0 +1,492 @@
+using System.Security.Cryptography;
+using System.Text;
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Platform.Windows.WinGet;
+
+internal sealed record WinGetPreparedPackage(
+    string PreparationId,
+    string RootDirectory,
+    string InstallerPath,
+    string InstallerType,
+    IReadOnlyList<string> SilentArguments,
+    IReadOnlySet<int> SuccessExitCodes)
+{
+    public PreparedInstallerCommand CreateInstallCommand(bool silent)
+    {
+        var type = InstallerType.ToLowerInvariant();
+        if (type is "msi" or "wix")
+        {
+            var systemDirectory = Environment.SystemDirectory;
+            if (string.IsNullOrWhiteSpace(systemDirectory))
+            {
+                throw new InvalidOperationException("Windows system directory is unavailable.");
+            }
+
+            var arguments = new List<string> { "/i", InstallerPath };
+            if (silent)
+            {
+                if (SilentArguments.Count > 0)
+                {
+                    arguments.AddRange(SilentArguments);
+                }
+                else
+                {
+                    arguments.Add("/qn");
+                    arguments.Add("/norestart");
+                }
+            }
+
+            return new PreparedInstallerCommand(
+                Path.Combine(systemDirectory, "msiexec.exe"),
+                arguments);
+        }
+
+        return new PreparedInstallerCommand(
+            InstallerPath,
+            silent ? SilentArguments : Array.Empty<string>());
+    }
+}
+
+internal sealed record PreparedInstallerCommand(
+    string ExecutablePath,
+    IReadOnlyList<string> Arguments);
+
+internal sealed record WinGetPreparedPackageInspection(
+    PackagePreparationStatus Status,
+    WinGetPreparedPackage? Package = null,
+    long? BytesDownloaded = null,
+    string? DiagnosticCode = null,
+    string? Message = null);
+
+internal static class WinGetPreparedPackageInspector
+{
+    private static readonly HashSet<string> SupportedInstallerTypes =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "exe",
+            "inno",
+            "nullsoft",
+            "burn",
+            "msi",
+            "wix"
+        };
+
+    public static WinGetPreparedPackageInspection Inspect(
+        string rootDirectory,
+        string expectedPackageId,
+        bool requireSilent)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedPackageId);
+
+        var root = Path.GetFullPath(rootDirectory);
+        if (!Directory.Exists(root))
+        {
+            return Failure(
+                "winget.preparation-output-missing",
+                "WinGet completed without a preparation directory.");
+        }
+
+        foreach (var manifestPath in Directory.EnumerateFiles(root, "*.yaml", SearchOption.AllDirectories))
+        {
+            if (!IsWithinRoot(root, manifestPath))
+            {
+                continue;
+            }
+
+            ParsedManifest manifest;
+            try
+            {
+                manifest = ParseManifest(File.ReadAllLines(manifestPath));
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            if (!string.Equals(
+                    manifest.PackageIdentifier,
+                    expectedPackageId,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (manifest.HasDependencies)
+            {
+                return Unsupported(
+                    "winget.preparation-dependencies",
+                    "This package declares dependencies, so AgenStart will let WinGet install it through the normal trusted path.");
+            }
+
+            if (string.IsNullOrWhiteSpace(manifest.InstallerSha256))
+            {
+                return Failure(
+                    "winget.preparation-hash-missing",
+                    "The prepared WinGet manifest did not contain an installer hash.");
+            }
+
+            var installerPath = FindHashMatchedInstaller(root, manifest.InstallerSha256);
+            if (installerPath is null)
+            {
+                return new WinGetPreparedPackageInspection(
+                    PackagePreparationStatus.IntegrityFailure,
+                    DiagnosticCode: "winget.preparation-hash-mismatch",
+                    Message: "AgenStart could not match the downloaded installer to the hash verified by the WinGet manifest.");
+            }
+
+            var installerType = ResolveInstallerType(manifest.InstallerType, installerPath);
+            if (!SupportedInstallerTypes.Contains(installerType))
+            {
+                return Unsupported(
+                    "winget.preparation-installer-type-unsupported",
+                    $"Prepared installation is not enabled for WinGet installer type '{installerType}'. The normal WinGet install path will be used.");
+            }
+
+            var silentArguments = ResolveSilentArguments(installerType, manifest.SilentSwitch);
+            if (requireSilent && silentArguments.Count == 0 && installerType is not "msi" and not "wix")
+            {
+                return Unsupported(
+                    "winget.preparation-silent-switch-unavailable",
+                    "The trusted manifest does not expose a safe silent invocation for this installer, so the normal WinGet install path will be used.");
+            }
+
+            var preparationId = Guid.NewGuid().ToString("N");
+            var successCodes = new HashSet<int>(manifest.SuccessExitCodes) { 0 };
+            var bytesDownloaded = new FileInfo(installerPath).Length;
+
+            return new WinGetPreparedPackageInspection(
+                PackagePreparationStatus.Ready,
+                new WinGetPreparedPackage(
+                    preparationId,
+                    root,
+                    installerPath,
+                    installerType,
+                    silentArguments,
+                    successCodes),
+                bytesDownloaded,
+                Message: "Installer hash verified; package is ready for sequential installation.");
+        }
+
+        return Failure(
+            "winget.preparation-manifest-missing",
+            "WinGet did not emit a merged manifest for the requested exact package.");
+    }
+
+    private static ParsedManifest ParseManifest(IReadOnlyList<string> lines)
+    {
+        string? packageIdentifier = null;
+        string? installerType = null;
+        string? installerSha256 = null;
+        string? silent = null;
+        var successCodes = new HashSet<int>();
+        var hasDependencies = false;
+
+        for (var index = 0; index < lines.Count; index++)
+        {
+            var raw = lines[index];
+            var trimmed = raw.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (packageIdentifier is null && TryReadValue(trimmed, "PackageIdentifier", out var packageValue))
+            {
+                packageIdentifier = Unquote(packageValue);
+                continue;
+            }
+
+            if (installerType is null && TryReadValue(trimmed, "InstallerType", out var typeValue))
+            {
+                installerType = Unquote(typeValue);
+                continue;
+            }
+
+            if (installerSha256 is null && TryReadValue(trimmed, "InstallerSha256", out var hashValue))
+            {
+                installerSha256 = Unquote(hashValue);
+                continue;
+            }
+
+            if (trimmed.Equals("Dependencies:", StringComparison.OrdinalIgnoreCase))
+            {
+                hasDependencies = true;
+                continue;
+            }
+
+            if (trimmed.Equals("InstallerSwitches:", StringComparison.OrdinalIgnoreCase))
+            {
+                var sectionIndent = LeadingWhitespace(raw);
+                for (var cursor = index + 1; cursor < lines.Count; cursor++)
+                {
+                    var candidateRaw = lines[cursor];
+                    if (string.IsNullOrWhiteSpace(candidateRaw))
+                    {
+                        continue;
+                    }
+
+                    if (LeadingWhitespace(candidateRaw) <= sectionIndent)
+                    {
+                        break;
+                    }
+
+                    var candidate = candidateRaw.Trim();
+                    if (TryReadValue(candidate, "Silent", out var silentValue))
+                    {
+                        silent = Unquote(silentValue);
+                    }
+                    else if (silent is null &&
+                             TryReadValue(candidate, "SilentWithProgress", out var progressValue))
+                    {
+                        silent = Unquote(progressValue);
+                    }
+                }
+
+                continue;
+            }
+
+            if (trimmed.Equals("InstallerSuccessCodes:", StringComparison.OrdinalIgnoreCase))
+            {
+                var sectionIndent = LeadingWhitespace(raw);
+                for (var cursor = index + 1; cursor < lines.Count; cursor++)
+                {
+                    var candidateRaw = lines[cursor];
+                    if (string.IsNullOrWhiteSpace(candidateRaw))
+                    {
+                        continue;
+                    }
+
+                    if (LeadingWhitespace(candidateRaw) <= sectionIndent)
+                    {
+                        break;
+                    }
+
+                    var candidate = candidateRaw.Trim();
+                    if (candidate.StartsWith("-", StringComparison.Ordinal))
+                    {
+                        var numeric = candidate[1..].Trim();
+                        if (int.TryParse(numeric, out var exitCode))
+                        {
+                            successCodes.Add(exitCode);
+                        }
+                    }
+                }
+            }
+        }
+
+        return new ParsedManifest(
+            packageIdentifier,
+            installerType,
+            installerSha256,
+            silent,
+            successCodes,
+            hasDependencies);
+    }
+
+    private static string? FindHashMatchedInstaller(string root, string expectedHash)
+    {
+        foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            if (!IsWithinRoot(root, file) ||
+                string.Equals(Path.GetExtension(file), ".yaml", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            try
+            {
+                using var stream = File.OpenRead(file);
+                var actualHash = Convert.ToHexString(SHA256.HashData(stream));
+                if (string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Path.GetFullPath(file);
+                }
+            }
+            catch (IOException)
+            {
+                // Ignore files that are still transient or cannot be read safely.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Ignore inaccessible dependency/license files.
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<string> ResolveSilentArguments(
+        string installerType,
+        string? manifestSwitch)
+    {
+        if (!string.IsNullOrWhiteSpace(manifestSwitch))
+        {
+            return SplitArguments(manifestSwitch);
+        }
+
+        return installerType.ToLowerInvariant() switch
+        {
+            "inno" => ["/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-"],
+            "nullsoft" => ["/S"],
+            "burn" => ["/quiet", "/norestart"],
+            "msi" or "wix" => ["/qn", "/norestart"],
+            _ => Array.Empty<string>()
+        };
+    }
+
+    internal static IReadOnlyList<string> SplitArguments(string commandLine)
+    {
+        var result = new List<string>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+        var quote = '\0';
+        var escaping = false;
+
+        foreach (var character in commandLine)
+        {
+            if (escaping)
+            {
+                current.Append(character);
+                escaping = false;
+                continue;
+            }
+
+            if (character == '\\' && inQuotes)
+            {
+                escaping = true;
+                continue;
+            }
+
+            if (character is '"' or '\'')
+            {
+                if (inQuotes && character == quote)
+                {
+                    inQuotes = false;
+                    quote = '\0';
+                }
+                else if (!inQuotes)
+                {
+                    inQuotes = true;
+                    quote = character;
+                }
+                else
+                {
+                    current.Append(character);
+                }
+
+                continue;
+            }
+
+            if (char.IsWhiteSpace(character) && !inQuotes)
+            {
+                if (current.Length > 0)
+                {
+                    result.Add(current.ToString());
+                    current.Clear();
+                }
+
+                continue;
+            }
+
+            current.Append(character);
+        }
+
+        if (escaping)
+        {
+            current.Append('\\');
+        }
+
+        if (current.Length > 0)
+        {
+            result.Add(current.ToString());
+        }
+
+        return result;
+    }
+
+    private static string ResolveInstallerType(string? manifestType, string installerPath)
+    {
+        if (!string.IsNullOrWhiteSpace(manifestType))
+        {
+            return manifestType.Trim();
+        }
+
+        return Path.GetExtension(installerPath).ToLowerInvariant() switch
+        {
+            ".msi" => "msi",
+            ".exe" => "exe",
+            ".msix" => "msix",
+            ".msixbundle" => "msixbundle",
+            ".appx" => "appx",
+            ".appxbundle" => "appxbundle",
+            _ => "unknown"
+        };
+    }
+
+    private static bool TryReadValue(string line, string key, out string value)
+    {
+        var prefix = key + ":";
+        if (line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            value = line[prefix.Length..].Trim();
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static string Unquote(string value)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length >= 2 &&
+            ((trimmed[0] == '"' && trimmed[^1] == '"') ||
+             (trimmed[0] == '\'' && trimmed[^1] == '\'')))
+        {
+            trimmed = trimmed[1..^1];
+        }
+
+        return trimmed
+            .Replace("''", "'", StringComparison.Ordinal)
+            .Replace("\\\"", "\"", StringComparison.Ordinal);
+    }
+
+    private static int LeadingWhitespace(string value)
+    {
+        var count = 0;
+        while (count < value.Length && char.IsWhiteSpace(value[count]))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static bool IsWithinRoot(string root, string path)
+    {
+        var fullRoot = Path.GetFullPath(root)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        var fullPath = Path.GetFullPath(path);
+        return fullPath.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static WinGetPreparedPackageInspection Unsupported(string code, string message) =>
+        new(PackagePreparationStatus.Unsupported, DiagnosticCode: code, Message: message);
+
+    private static WinGetPreparedPackageInspection Failure(string code, string message) =>
+        new(PackagePreparationStatus.Failed, DiagnosticCode: code, Message: message);
+
+    private sealed record ParsedManifest(
+        string? PackageIdentifier,
+        string? InstallerType,
+        string? InstallerSha256,
+        string? SilentSwitch,
+        IReadOnlySet<int> SuccessExitCodes,
+        bool HasDependencies);
+}

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetPreparedPackage.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetPreparedPackage.cs
@@ -8,6 +8,7 @@ internal sealed record WinGetPreparedPackage(
     string PreparationId,
     string RootDirectory,
     string InstallerPath,
+    string InstallerSha256,
     string InstallerType,
     IReadOnlyList<string> SilentArguments,
     IReadOnlySet<int> SuccessExitCodes)
@@ -166,6 +167,7 @@ internal static class WinGetPreparedPackageInspector
                     preparationId,
                     root,
                     installerPath,
+                    manifest.InstallerSha256,
                     installerType,
                     silentArguments,
                     successCodes),
@@ -191,7 +193,7 @@ internal static class WinGetPreparedPackageInspector
         {
             var raw = lines[index];
             var trimmed = raw.Trim();
-            if (trimmed.Length == 0 || trimmed.StartsWith('#'))
+            if (trimmed.Length == 0 || trimmed[0] == '#')
             {
                 continue;
             }
@@ -468,7 +470,7 @@ internal static class WinGetPreparedPackageInspector
         return count;
     }
 
-    private static bool IsWithinRoot(string root, string path)
+    internal static bool IsWithinRoot(string root, string path)
     {
         var fullRoot = Path.GetFullPath(root)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;

--- a/src/AgenStart.Platform.Windows/WinGet/WinGetProvider.cs
+++ b/src/AgenStart.Platform.Windows/WinGet/WinGetProvider.cs
@@ -1,16 +1,22 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using AgenStart.PackageManagement;
 
 namespace AgenStart.Platform.Windows.WinGet;
 
-public sealed partial class WinGetProvider : IPackageProvider
+public sealed partial class WinGetProvider : IPreparablePackageProvider
 {
     private static readonly TimeSpan AvailabilityTimeout = TimeSpan.FromSeconds(8);
     private static readonly TimeSpan ResolveTimeout = TimeSpan.FromSeconds(45);
+    private static readonly TimeSpan DownloadTimeout = TimeSpan.FromMinutes(30);
     private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(30);
 
     private readonly IWinGetExecutableLocator _locator;
     private readonly IWinGetProcessRunner _runner;
+    private readonly string _preparationRoot;
+    private readonly ConcurrentDictionary<string, WinGetPreparedPackage> _preparedPackages =
+        new(StringComparer.OrdinalIgnoreCase);
 
     public WinGetProvider()
         : this(new WinGetExecutableLocator(), new WinGetProcessRunner())
@@ -19,13 +25,32 @@ public sealed partial class WinGetProvider : IPackageProvider
 
     public WinGetProvider(
         IWinGetExecutableLocator locator,
-        IWinGetProcessRunner runner)
+        IWinGetProcessRunner runner,
+        string? preparationRoot = null)
     {
         _locator = locator ?? throw new ArgumentNullException(nameof(locator));
         _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _preparationRoot = ResolvePreparationRoot(preparationRoot);
     }
 
     public string ProviderId => PackageProviderIds.WinGet;
+
+    public bool CanPrepare(ProviderPackageReference package)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        try
+        {
+            WinGetCommandBuilder.ValidateReference(package);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        // Store packages need account/licensing semantics that are intentionally left to WinGet.
+        return string.Equals(package.Source, "winget", StringComparison.OrdinalIgnoreCase);
+    }
 
     public async Task<PackageProviderAvailability> CheckAvailabilityAsync(
         CancellationToken cancellationToken = default)
@@ -123,6 +148,222 @@ public sealed partial class WinGetProvider : IPackageProvider
             MessageFor(normalized.Status));
     }
 
+    public async Task<PackagePreparationResult> PrepareAsync(
+        PackageInstallRequest request,
+        IProgress<PackagePreparationProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!CanPrepare(request.Package))
+        {
+            return new PackagePreparationResult(
+                PackagePreparationStatus.Unsupported,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.preparation-not-supported",
+                Message: "This trusted WinGet source is not eligible for local package preparation.");
+        }
+
+        var preparationDirectory = Path.Combine(_preparationRoot, Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(preparationDirectory);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return new PackagePreparationResult(
+                PackagePreparationStatus.Failed,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.preparation-directory-unavailable",
+                Message: "AgenStart could not create its local package preparation directory.");
+        }
+
+        WinGetCommand command;
+        try
+        {
+            command = WinGetCommandBuilder.BuildDownload(request, preparationDirectory);
+        }
+        catch (ArgumentException exception)
+        {
+            TryDeleteDirectory(preparationDirectory);
+            return new PackagePreparationResult(
+                PackagePreparationStatus.Failed,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.invalid-download-request",
+                Message: exception.Message);
+        }
+
+        var executable = _locator.Resolve();
+        if (!executable.Found || string.IsNullOrWhiteSpace(executable.Path))
+        {
+            TryDeleteDirectory(preparationDirectory);
+            return new PackagePreparationResult(
+                PackagePreparationStatus.ProviderUnavailable,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: executable.DiagnosticCode,
+                Message: executable.Message);
+        }
+
+        progress?.Report(new PackagePreparationProgress(
+            BytesDownloaded: 0,
+            Message: $"Downloading {request.ApplicationId} through WinGet."));
+
+        var processResult = await _runner.RunAsync(
+            executable.Path,
+            command.Arguments,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        var normalized = WinGetResultNormalizer.Normalize(processResult);
+
+        if (normalized.Status != PackageOperationStatus.Succeeded)
+        {
+            TryDeleteDirectory(preparationDirectory);
+            return new PackagePreparationResult(
+                ToPreparationStatus(normalized.Status),
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: normalized.DiagnosticCode,
+                Message: MessageFor(normalized.Status));
+        }
+
+        var inspection = WinGetPreparedPackageInspector.Inspect(
+            preparationDirectory,
+            request.Package.PackageId,
+            request.Silent);
+
+        if (inspection.Status != PackagePreparationStatus.Ready || inspection.Package is null)
+        {
+            TryDeleteDirectory(preparationDirectory);
+            return new PackagePreparationResult(
+                inspection.Status,
+                request.ApplicationId,
+                request.Package,
+                BytesDownloaded: inspection.BytesDownloaded,
+                DiagnosticCode: inspection.DiagnosticCode,
+                Message: inspection.Message);
+        }
+
+        if (!_preparedPackages.TryAdd(inspection.Package.PreparationId, inspection.Package))
+        {
+            TryDeleteDirectory(preparationDirectory);
+            return new PackagePreparationResult(
+                PackagePreparationStatus.Failed,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.preparation-id-collision",
+                Message: "AgenStart could not register the prepared package safely.");
+        }
+
+        progress?.Report(new PackagePreparationProgress(
+            BytesDownloaded: inspection.BytesDownloaded,
+            BytesRequired: inspection.BytesDownloaded,
+            Fraction: 1,
+            Message: $"{request.ApplicationId} is ready to install."));
+
+        return new PackagePreparationResult(
+            PackagePreparationStatus.Ready,
+            request.ApplicationId,
+            request.Package,
+            inspection.Package.PreparationId,
+            inspection.BytesDownloaded,
+            inspection.DiagnosticCode,
+            inspection.Message);
+    }
+
+    public async Task<PackageOperationResult> InstallPreparedAsync(
+        PackageInstallRequest request,
+        PackagePreparationResult preparation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(preparation);
+
+        if (!preparation.IsReady ||
+            !string.Equals(preparation.ApplicationId, request.ApplicationId, StringComparison.OrdinalIgnoreCase) ||
+            preparation.Package != request.Package ||
+            !_preparedPackages.TryGetValue(preparation.PreparationId!, out var prepared))
+        {
+            return new PackageOperationResult(
+                PackageOperationStatus.Failed,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.preparation-invalid",
+                Message: "The prepared package does not match the approved installation request.");
+        }
+
+        if (!WinGetPreparedPackageInspector.IsWithinRoot(prepared.RootDirectory, prepared.InstallerPath) ||
+            !File.Exists(prepared.InstallerPath))
+        {
+            return new PackageOperationResult(
+                PackageOperationStatus.IntegrityFailure,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.prepared-installer-missing",
+                Message: "The prepared installer is no longer available in AgenStart's package cache.");
+        }
+
+        if (!VerifyInstallerHash(prepared.InstallerPath, prepared.InstallerSha256))
+        {
+            return new PackageOperationResult(
+                PackageOperationStatus.IntegrityFailure,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.prepared-installer-hash-mismatch",
+                Message: "The prepared installer changed after download and was blocked before execution.");
+        }
+
+        PreparedInstallerCommand command;
+        try
+        {
+            command = prepared.CreateInstallCommand(request.Silent);
+        }
+        catch (InvalidOperationException)
+        {
+            return new PackageOperationResult(
+                PackageOperationStatus.ProviderUnavailable,
+                request.ApplicationId,
+                request.Package,
+                DiagnosticCode: "winget.prepared-installer-launch-unavailable",
+                Message: "Windows could not provide a trusted local installer launch path.");
+        }
+
+        var processResult = await _runner.RunAsync(
+            command.ExecutablePath,
+            command.Arguments,
+            InstallTimeout,
+            cancellationToken).ConfigureAwait(false);
+
+        var status = NormalizePreparedInstallerResult(processResult, prepared.SuccessExitCodes);
+        return new PackageOperationResult(
+            status,
+            request.ApplicationId,
+            request.Package,
+            processResult.ExitCode,
+            DiagnosticForPreparedInstaller(status),
+            MessageForPreparedInstaller(status));
+    }
+
+    public Task ReleasePreparationAsync(
+        PackagePreparationResult preparation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(preparation);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(preparation.PreparationId) ||
+            !_preparedPackages.TryRemove(preparation.PreparationId, out var prepared))
+        {
+            return Task.CompletedTask;
+        }
+
+        TryDeleteDirectory(prepared.RootDirectory);
+        return Task.CompletedTask;
+    }
+
     public async Task<PackageOperationResult> InstallAsync(
         PackageInstallRequest request,
         CancellationToken cancellationToken = default)
@@ -173,6 +414,131 @@ public sealed partial class WinGetProvider : IPackageProvider
 
     [GeneratedRegex(@"\bv?(\d+(?:\.\d+){1,3}(?:[-+][A-Za-z0-9.-]+)?)\b", RegexOptions.CultureInvariant)]
     private static partial Regex VersionPattern();
+
+    private static string ResolvePreparationRoot(string? configuredRoot)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredRoot))
+        {
+            if (!Path.IsPathFullyQualified(configuredRoot))
+            {
+                throw new ArgumentException(
+                    "Package preparation root must be an absolute path.",
+                    nameof(configuredRoot));
+            }
+
+            return Path.GetFullPath(configuredRoot);
+        }
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var baseDirectory = string.IsNullOrWhiteSpace(localAppData)
+            ? Path.GetTempPath()
+            : localAppData;
+        return Path.GetFullPath(Path.Combine(baseDirectory, "AgenStart", "PackageCache"));
+    }
+
+    private static bool VerifyInstallerHash(string path, string expectedHash)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            var actualHash = Convert.ToHexString(SHA256.HashData(stream));
+            return string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static PackageOperationStatus NormalizePreparedInstallerResult(
+        WinGetProcessResult result,
+        IReadOnlySet<int> successExitCodes)
+    {
+        if (result.Cancelled)
+        {
+            return PackageOperationStatus.Cancelled;
+        }
+
+        if (result.TimedOut)
+        {
+            return PackageOperationStatus.TimedOut;
+        }
+
+        if (!result.Started || result.ExitCode is null)
+        {
+            return result.StartError?.Contains("elevation", StringComparison.OrdinalIgnoreCase) == true
+                ? PackageOperationStatus.RequiresElevation
+                : PackageOperationStatus.Failed;
+        }
+
+        if (result.ExitCode is 3010 or 1641)
+        {
+            return PackageOperationStatus.RebootRequired;
+        }
+
+        if (result.ExitCode == 1602)
+        {
+            return PackageOperationStatus.CancelledByUser;
+        }
+
+        return successExitCodes.Contains(result.ExitCode.Value)
+            ? PackageOperationStatus.Succeeded
+            : PackageOperationStatus.Failed;
+    }
+
+    private static PackagePreparationStatus ToPreparationStatus(PackageOperationStatus status) => status switch
+    {
+        PackageOperationStatus.SourceUnavailable => PackagePreparationStatus.SourceUnavailable,
+        PackageOperationStatus.AgreementRequired => PackagePreparationStatus.AgreementRequired,
+        PackageOperationStatus.BlockedByPolicy => PackagePreparationStatus.BlockedByPolicy,
+        PackageOperationStatus.IntegrityFailure => PackagePreparationStatus.IntegrityFailure,
+        PackageOperationStatus.NetworkFailure => PackagePreparationStatus.NetworkFailure,
+        PackageOperationStatus.Cancelled or PackageOperationStatus.CancelledByUser => PackagePreparationStatus.Cancelled,
+        PackageOperationStatus.TimedOut => PackagePreparationStatus.TimedOut,
+        PackageOperationStatus.ProviderUnavailable => PackagePreparationStatus.ProviderUnavailable,
+        _ => PackagePreparationStatus.Failed
+    };
+
+    private static string DiagnosticForPreparedInstaller(PackageOperationStatus status) => status switch
+    {
+        PackageOperationStatus.Succeeded => "winget.prepared-installer-success",
+        PackageOperationStatus.RebootRequired => "winget.prepared-installer-reboot-required",
+        PackageOperationStatus.CancelledByUser => "winget.prepared-installer-cancelled-by-user",
+        PackageOperationStatus.Cancelled => "winget.prepared-installer-cancelled",
+        PackageOperationStatus.TimedOut => "winget.prepared-installer-timeout",
+        PackageOperationStatus.RequiresElevation => "winget.prepared-installer-requires-elevation",
+        _ => "winget.prepared-installer-failed"
+    };
+
+    private static string MessageForPreparedInstaller(PackageOperationStatus status) => status switch
+    {
+        PackageOperationStatus.Succeeded => "The hash-verified prepared installer completed successfully.",
+        PackageOperationStatus.RebootRequired => "The hash-verified prepared installer completed and requires a reboot.",
+        PackageOperationStatus.CancelledByUser => "The prepared installer was cancelled by the user.",
+        PackageOperationStatus.Cancelled => "The prepared installer was cancelled.",
+        PackageOperationStatus.TimedOut => "The prepared installer exceeded its execution timeout.",
+        PackageOperationStatus.RequiresElevation => "The prepared installer requires elevation; retry through the normal trusted WinGet path.",
+        _ => "The prepared installer returned a non-success result."
+    };
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Cache cleanup is best-effort.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Cache cleanup is best-effort.
+        }
+    }
 
     private static string? ParseVersion(string output)
     {

--- a/tests/AgenStart.Application.Tests/PackagePreparationPipelineTests.cs
+++ b/tests/AgenStart.Application.Tests/PackagePreparationPipelineTests.cs
@@ -1,0 +1,268 @@
+using AgenStart.Application.Installation;
+using AgenStart.PackageManagement;
+
+namespace AgenStart.Application.Tests;
+
+public sealed class PackagePreparationPipelineTests
+{
+    [Fact]
+    public async Task RunAsync_PreparesPackagesConcurrentlyButInstallsSequentially()
+    {
+        var provider = new PreparingProvider();
+        var verifier = new ProviderBackedVerifier(provider);
+        var orchestrator = new InstallationOrchestrator(
+            [provider],
+            verifier,
+            preparationConcurrency: 3);
+        using var session = orchestrator.CreateSession(
+        [
+            Selection("git"),
+            Selection("7zip"),
+            Selection("visual-studio-code")
+        ]);
+
+        var report = await orchestrator.RunAsync(
+            session,
+            TestContext.Current.CancellationToken);
+
+        Assert.InRange(provider.MaxPreparationConcurrency, 2, 3);
+        Assert.Equal(1, provider.MaxInstallConcurrency);
+        Assert.Equal(
+            ["git", "7zip", "visual-studio-code"],
+            provider.InstallOrder);
+        Assert.Equal(3, report.SucceededCount);
+        Assert.All(
+            report.Items,
+            item => Assert.Equal(InstallationItemActivity.Completed, item.Activity));
+    }
+
+    [Fact]
+    public async Task RunAsync_PreparationFailureDoesNotCorruptOtherQueueItems()
+    {
+        var provider = new PreparingProvider("7zip");
+        var verifier = new ProviderBackedVerifier(provider);
+        var orchestrator = new InstallationOrchestrator(
+            [provider],
+            verifier,
+            preparationConcurrency: 3);
+        using var session = orchestrator.CreateSession(
+        [
+            Selection("git"),
+            Selection("7zip"),
+            Selection("visual-studio-code")
+        ]);
+
+        var report = await orchestrator.RunAsync(
+            session,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, report.SucceededCount);
+        Assert.Equal(1, report.FailedCount);
+        Assert.Equal(["git", "visual-studio-code"], provider.InstallOrder);
+
+        var failed = Assert.Single(report.Items, item => item.ApplicationId == "7zip");
+        Assert.Equal(InstallationQueueItemState.Failed, failed.State);
+        Assert.Equal(InstallationItemActivity.Failed, failed.Activity);
+        Assert.True(failed.CanRetry);
+        Assert.Equal(PackageOperationStatus.NetworkFailure, failed.LastOperationStatus);
+    }
+
+    [Fact]
+    public async Task RunAsync_CancellationStopsActivePreparationsBeforeInstallerExecution()
+    {
+        var provider = new PreparingProvider(preparationDelay: TimeSpan.FromSeconds(5));
+        var verifier = new ProviderBackedVerifier(provider);
+        var orchestrator = new InstallationOrchestrator(
+            [provider],
+            verifier,
+            preparationConcurrency: 3);
+        using var session = orchestrator.CreateSession(
+        [
+            Selection("git"),
+            Selection("7zip"),
+            Selection("visual-studio-code")
+        ]);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        cancellation.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        var report = await orchestrator.RunAsync(session, cancellation.Token);
+
+        Assert.Equal(InstallationSessionState.Cancelled, report.State);
+        Assert.Empty(provider.InstallOrder);
+        Assert.All(
+            report.Items,
+            item => Assert.Equal(InstallationQueueItemState.Cancelled, item.State));
+    }
+
+    private static InstallationSelection Selection(string applicationId) =>
+        new(
+            applicationId,
+            new ProviderPackageReference(
+                PackageProviderIds.WinGet,
+                $"Example.{applicationId}",
+                "winget"),
+            Approved: true);
+
+    private sealed class ProviderBackedVerifier(PreparingProvider provider) : IInstallationVerifier
+    {
+        public Task<InstallationVerificationResult> VerifyAsync(
+            string applicationId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(provider.IsInstalled(applicationId)
+                ? new InstallationVerificationResult(
+                    InstallationVerificationStatus.Verified,
+                    "1.0.0")
+                : new InstallationVerificationResult(InstallationVerificationStatus.NotInstalled));
+        }
+    }
+
+    private sealed class PreparingProvider : IPreparablePackageProvider
+    {
+        private readonly string? _preparationFailureApplicationId;
+        private readonly TimeSpan _preparationDelay;
+        private readonly HashSet<string> _installed = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object _gate = new();
+        private int _activePreparations;
+        private int _maxPreparationConcurrency;
+        private int _activeInstalls;
+        private int _maxInstallConcurrency;
+
+        public PreparingProvider(
+            string? preparationFailureApplicationId = null,
+            TimeSpan? preparationDelay = null)
+        {
+            _preparationFailureApplicationId = preparationFailureApplicationId;
+            _preparationDelay = preparationDelay ?? TimeSpan.FromMilliseconds(80);
+        }
+
+        public string ProviderId => PackageProviderIds.WinGet;
+        public List<string> InstallOrder { get; } = [];
+        public int MaxPreparationConcurrency => Volatile.Read(ref _maxPreparationConcurrency);
+        public int MaxInstallConcurrency => Volatile.Read(ref _maxInstallConcurrency);
+
+        public bool IsInstalled(string applicationId)
+        {
+            lock (_gate)
+            {
+                return _installed.Contains(applicationId);
+            }
+        }
+
+        public bool CanPrepare(ProviderPackageReference package) => true;
+
+        public Task<PackageProviderAvailability> CheckAvailabilityAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new PackageProviderAvailability(
+                PackageProviderAvailabilityStatus.Available,
+                "1.12.0"));
+        }
+
+        public Task<PackageResolutionResult> ResolveAsync(
+            ProviderPackageReference package,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new PackageResolutionResult(
+                PackageResolutionStatus.Resolved,
+                package));
+        }
+
+        public async Task<PackagePreparationResult> PrepareAsync(
+            PackageInstallRequest request,
+            IProgress<PackagePreparationProgress>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            var active = Interlocked.Increment(ref _activePreparations);
+            UpdateMax(ref _maxPreparationConcurrency, active);
+            try
+            {
+                progress?.Report(new PackagePreparationProgress(
+                    BytesDownloaded: 1024,
+                    Message: "Downloading test package."));
+                await Task.Delay(_preparationDelay, cancellationToken);
+
+                if (string.Equals(
+                        request.ApplicationId,
+                        _preparationFailureApplicationId,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return new PackagePreparationResult(
+                        PackagePreparationStatus.NetworkFailure,
+                        request.ApplicationId,
+                        request.Package,
+                        DiagnosticCode: "test.download-failed",
+                        Message: "Synthetic network failure.");
+                }
+
+                return new PackagePreparationResult(
+                    PackagePreparationStatus.Ready,
+                    request.ApplicationId,
+                    request.Package,
+                    PreparationId: $"prepared-{request.ApplicationId}",
+                    BytesDownloaded: 4096);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _activePreparations);
+            }
+        }
+
+        public async Task<PackageOperationResult> InstallPreparedAsync(
+            PackageInstallRequest request,
+            PackagePreparationResult preparation,
+            CancellationToken cancellationToken = default)
+        {
+            var active = Interlocked.Increment(ref _activeInstalls);
+            UpdateMax(ref _maxInstallConcurrency, active);
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(20), cancellationToken);
+                lock (_gate)
+                {
+                    InstallOrder.Add(request.ApplicationId);
+                    _installed.Add(request.ApplicationId);
+                }
+
+                return new PackageOperationResult(
+                    PackageOperationStatus.Succeeded,
+                    request.ApplicationId,
+                    request.Package);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _activeInstalls);
+            }
+        }
+
+        public Task ReleasePreparationAsync(
+            PackagePreparationResult preparation,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<PackageOperationResult> InstallAsync(
+            PackageInstallRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("Prepared test packages must use InstallPreparedAsync.");
+
+        private static void UpdateMax(ref int target, int candidate)
+        {
+            while (true)
+            {
+                var current = Volatile.Read(ref target);
+                if (candidate <= current ||
+                    Interlocked.CompareExchange(ref target, candidate, current) == current)
+                {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/tests/AgenStart.Platform.Windows.Tests/WinGetPreparationTests.cs
+++ b/tests/AgenStart.Platform.Windows.Tests/WinGetPreparationTests.cs
@@ -1,0 +1,212 @@
+using System.Security.Cryptography;
+using System.Text;
+using AgenStart.PackageManagement;
+using AgenStart.Platform.Windows.WinGet;
+
+namespace AgenStart.Platform.Windows.Tests;
+
+public sealed class WinGetPreparationTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        "AgenStartTests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void BuildDownload_UsesExactTrustedPackageWithoutSecurityBypasses()
+    {
+        var request = Request("git", "Git.Git");
+        var output = Path.Combine(_root, "download");
+
+        var command = WinGetCommandBuilder.BuildDownload(request, output);
+
+        Assert.Equal("download", command.Arguments[0]);
+        Assert.Contains("--id", command.Arguments);
+        Assert.Contains("Git.Git", command.Arguments);
+        Assert.Contains("--exact", command.Arguments);
+        Assert.Contains("--source", command.Arguments);
+        Assert.Contains("winget", command.Arguments);
+        Assert.Contains("--download-directory", command.Arguments);
+        Assert.Contains(output, command.Arguments);
+        Assert.DoesNotContain("--ignore-security-hash", command.Arguments);
+        Assert.DoesNotContain("--force", command.Arguments);
+        Assert.DoesNotContain("--override", command.Arguments);
+    }
+
+    [Fact]
+    public async Task PrepareAndInstallPreparedAsync_RechecksHashAndExecutesPreparedInstaller()
+    {
+        Directory.CreateDirectory(_root);
+        var runner = new PreparationRunner("Git.Git");
+        var provider = new WinGetProvider(
+            new FakeLocator("C:\\Trusted\\winget.exe"),
+            runner,
+            _root);
+        var request = Request("git", "Git.Git");
+
+        var preparation = await provider.PrepareAsync(
+            request,
+            cancellationToken: TestContext.Current.CancellationToken);
+        var operation = await provider.InstallPreparedAsync(
+            request,
+            preparation,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(preparation.IsReady);
+        Assert.Equal(PackageOperationStatus.Succeeded, operation.Status);
+        Assert.Single(runner.PreparedInstallerCalls);
+        Assert.DoesNotContain(
+            runner.PreparedInstallerCalls[0].Arguments,
+            argument => argument.Contains("http", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task InstallPreparedAsync_BlocksInstallerThatChangesAfterPreparation()
+    {
+        Directory.CreateDirectory(_root);
+        var runner = new PreparationRunner("Git.Git");
+        var provider = new WinGetProvider(
+            new FakeLocator("C:\\Trusted\\winget.exe"),
+            runner,
+            _root);
+        var request = Request("git", "Git.Git");
+
+        var preparation = await provider.PrepareAsync(
+            request,
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(preparation.IsReady);
+
+        var installer = Assert.Single(
+            Directory.EnumerateFiles(_root, "*.exe", SearchOption.AllDirectories));
+        await File.WriteAllTextAsync(
+            installer,
+            "tampered",
+            TestContext.Current.CancellationToken);
+
+        var operation = await provider.InstallPreparedAsync(
+            request,
+            preparation,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(PackageOperationStatus.IntegrityFailure, operation.Status);
+        Assert.Equal("winget.prepared-installer-hash-mismatch", operation.DiagnosticCode);
+        Assert.Empty(runner.PreparedInstallerCalls);
+    }
+
+    [Fact]
+    public void CanPrepare_DoesNotPreDownloadMicrosoftStorePackages()
+    {
+        var provider = new WinGetProvider(
+            new FakeLocator("C:\\Trusted\\winget.exe"),
+            new PreparationRunner("Example.Store"),
+            _root);
+        var storePackage = new ProviderPackageReference(
+            PackageProviderIds.WinGet,
+            "9NBLGGH4NNS1",
+            "msstore");
+
+        Assert.False(provider.CanPrepare(storePackage));
+    }
+
+    private static PackageInstallRequest Request(string applicationId, string packageId) =>
+        new(
+            applicationId,
+            new ProviderPackageReference(
+                PackageProviderIds.WinGet,
+                packageId,
+                "winget"),
+            Silent: true,
+            AcceptPackageAgreements: true,
+            AcceptSourceAgreements: true);
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private sealed class FakeLocator(string path) : IWinGetExecutableLocator
+    {
+        public WinGetExecutableResolution Resolve() => new(true, path);
+    }
+
+    private sealed class PreparationRunner(string packageId) : IWinGetProcessRunner
+    {
+        public List<Call> PreparedInstallerCalls { get; } = [];
+
+        public Task<WinGetProcessResult> RunAsync(
+            string executablePath,
+            IReadOnlyList<string> arguments,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (arguments.Count > 0 &&
+                string.Equals(arguments[0], "download", StringComparison.OrdinalIgnoreCase))
+            {
+                var directoryIndex = IndexOf(arguments, "--download-directory");
+                Assert.True(directoryIndex >= 0);
+                var directory = arguments[directoryIndex + 1];
+                Directory.CreateDirectory(directory);
+
+                var installerPath = Path.Combine(directory, "installer.exe");
+                var installerBytes = Encoding.UTF8.GetBytes("trusted prepared installer");
+                File.WriteAllBytes(installerPath, installerBytes);
+                var hash = Convert.ToHexString(SHA256.HashData(installerBytes));
+                File.WriteAllText(
+                    Path.Combine(directory, "manifest.yaml"),
+                    $"""
+                    PackageIdentifier: {packageId}
+                    InstallerType: exe
+                    InstallerSha256: {hash}
+                    InstallerSwitches:
+                      Silent: /S
+                    InstallerSuccessCodes:
+                      - 0
+                    """);
+
+                return Task.FromResult(new WinGetProcessResult(
+                    true,
+                    0,
+                    string.Empty,
+                    string.Empty));
+            }
+
+            PreparedInstallerCalls.Add(new Call(executablePath, arguments.ToArray()));
+            return Task.FromResult(new WinGetProcessResult(
+                true,
+                0,
+                string.Empty,
+                string.Empty));
+        }
+
+        private static int IndexOf(IReadOnlyList<string> values, string expected)
+        {
+            for (var index = 0; index < values.Count; index++)
+            {
+                if (string.Equals(values[index], expected, StringComparison.OrdinalIgnoreCase))
+                {
+                    return index;
+                }
+            }
+
+            return -1;
+        }
+    }
+
+    private sealed record Call(
+        string ExecutablePath,
+        IReadOnlyList<string> Arguments);
+}


### PR DESCRIPTION
## Summary

Implement the v0.2 package preparation pipeline from #49 while preserving AgenStart's deterministic installation and trust boundaries.

### Pipeline
- prepare up to 3 approved packages concurrently by default
- keep installer execution strictly sequential and in approved order
- expose item activity as Resolving / Downloading / Ready / Installing / Verifying / terminal state
- isolate preparation failures so they do not corrupt the rest of the queue
- propagate cancellation to active preparation and installation work
- retain prepared packages for explicit retry when safe

### WinGet trust boundary
- use exact `winget download --id ... --exact --source ...` into an AgenStart-owned staging directory
- never use `--override`, `--force`, arbitrary installer URLs, or security-hash bypasses
- independently match the WinGet-emitted manifest package ID and SHA-256
- re-check SHA-256 immediately before prepared execution
- conservatively support direct preparation for common EXE/Inno/Nullsoft/Burn/MSI/Wix packages
- fall back to normal WinGet installation for unsupported preparation shapes, dependencies, and Microsoft Store packages
- preserve post-install inventory verification before success is reported

### UI
- installation rows now expose the real preparation activity instead of showing every queued item as only Waiting/Installing
- statuses distinguish Resolving, Downloading, Ready, Installing, Verifying and Verified/Failed/Cancelled

### Tests
- bounded concurrent preparation with overlapping package preparation
- sequential installer execution despite parallel preparation
- preparation failure isolation
- cancellation before installer execution
- exact WinGet download command and no security bypass flags
- prepared installer hash verification and tamper rejection
- Store preparation fallback

Closes #49